### PR TITLE
schemas: duration_type -> phase, +duration_days +context

### DIFF
--- a/isaric/schemas.py
+++ b/isaric/schemas.py
@@ -11,6 +11,7 @@ from .taxonomy import (
     ObservationName,
     Outcome,
     Pathogen,
+    Phase,
     PregnancyGestationalOutcome,
     ReferenceDate,
     Sex,

--- a/isaric/schemas.py
+++ b/isaric/schemas.py
@@ -173,5 +173,5 @@ class Observation(BaseModel):
     value_num: float | None = None
     value_char: str | None = None
     is_present: bool | None = None
-    duration_days: int = None
-    context: str = None
+    occurrence_duration: str = None
+    context: list[str] = None

--- a/isaric/schemas.py
+++ b/isaric/schemas.py
@@ -174,5 +174,5 @@ class Observation(BaseModel):
     value_num: float | None = None
     value_char: str | None = None
     is_present: bool | None = None
-    occurrence_duration: str = None
+    occurrence_period: str = None
     context: list[str] = None

--- a/isaric/schemas.py
+++ b/isaric/schemas.py
@@ -102,9 +102,10 @@ class Visit(BaseModel):
     subject_id: int
     study_id: str
     study_version: PositiveInt
-    start_date: datetime.date
+    date: datetime.date
     end_date: datetime.date
-    duration_type: VisitDuration = VisitDuration.admission
+    phase: Phase = None
+    duration_days: int = None
 
     pathogen_test_date: datetime.date | None = None
     icu_admission: bool | None = None
@@ -165,9 +166,12 @@ class Observation(BaseModel):
     study_id: str
     study_version: PositiveInt
 
+    phase: Phase
     date: datetime.datetime
+    name: ObservationName
     end_date: datetime.datetime | None = None
     value_num: float | None = None
     value_char: str | None = None
     is_present: bool | None = None
-    name: ObservationName
+    duration_days: int = None
+    context: str = None

--- a/isaric/taxonomy/__init__.py
+++ b/isaric/taxonomy/__init__.py
@@ -22,6 +22,7 @@ Ethnicity = load_taxonomy("Ethnicity", TAXONOMY_VERSION)
 Observation = load_taxonomy("Observation", TAXONOMY_VERSION)
 Outcome = load_taxonomy("Outcome", TAXONOMY_VERSION)
 Pathogen = load_taxonomy("Pathogen", TAXONOMY_VERSION)
+Phase = load_taxonomy("Pathogen", TAXONOMY_VERSION)
 PregnancyGestationalOutcome = load_taxonomy(
     "PregnancyGestationalOutcome", TAXONOMY_VERSION
 )

--- a/isaric/taxonomy/v1.json
+++ b/isaric/taxonomy/v1.json
@@ -26,10 +26,10 @@
       "confirmation/laboratory",
       "admission"
     ],
-    "VisitDuration": [
-      "before_admission",
+    "Phase": [
       "admission",
-      "post_admission"
+      "study",
+      "followup"
     ],
     "Outcome": [
       "death",


### PR DESCRIPTION
start_date -> date (in visit)
  Brings this in line with date in observations

duration_days (int)
  Refers to the time period in which observation happened.
  Reference for duration_days is date

context (str)
  Refers to the context of an observation. For example, if
  the observation is temperature, could refer to axillary
  or ear, or if the observation is oxygen saturation, could
  refer to whether the measurement happened in room air
  or post oxygen therapy.
