### PR TITLE
ci: add parser validation script and workflow

### DIFF
--- a/.github/workflows/parsers.yml
+++ b/.github/workflows/parsers.yml
@@ -1,0 +1,33 @@
+name: parsers
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - 'isaric/parsers/*.toml'
+    - 'ci/validate_parser.py'
+    - '.github/workflows/parsers.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+    - 'isaric/parsers/*.toml'
+    - 'ci/validate_parser.py'
+    - '.github/workflows/parsers.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: python3 -m pip install -r ci/requirements.txt
+    - name: Validate parsers
+      run: |
+        python3 ci/validate_parser.py isaric/parsers/*.toml

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,0 +1,2 @@
+tomli
+fastjsonschema

--- a/ci/validate_parser.py
+++ b/ci/validate_parser.py
@@ -1,0 +1,55 @@
+"""
+Flag in CI if parser fails validation
+"""
+
+import sys
+import json
+from pathlib import Path
+from typing import Tuple
+
+import tomli
+import fastjsonschema
+
+
+def validate(file: str) -> Tuple[str, bool, str]:
+    "Validates file and returns a tuple of whether file is valid and a string error message"
+    schema_header = Path(file).read_text().split()[:2]
+    if (
+        schema_header[0] == "#:schema"
+    ):  # hint to EvenBetterTOML, next line is the schema file
+        schema_file_relative = schema_header[1]
+        schema_file_path = Path(file).parent / schema_file_relative
+        if not schema_file_path.exists():
+            raise FileNotFoundError(f"Schema file not found at: {schema_file_path}")
+        with schema_file_path.open() as fp:
+            schema_validate = fastjsonschema.compile(json.load(fp))
+    else:
+        return file, False, "no schema found"
+
+    with open(file, "rb") as fp:
+        data = tomli.load(fp)
+    try:
+        schema_validate(data)
+    except fastjsonschema.exceptions.JsonSchemaValueException as e:
+        return file, False, e.message
+    return file, True, ""
+
+
+def message(file, valid, error_message):
+    return f" OK {file}" if valid else f"ERR {file}: {error_message}"
+
+
+files = sys.argv[1:]
+if not files:
+    print(
+        """usage: {sys.argv[0]} files...
+    Validate parser file(s) according to schema directive"""
+    )
+    sys.exit(0)
+
+any_invalid = False
+for file, valid, error_message in map(validate, files):
+    any_invalid |= not valid
+    print(message(file, valid, error_message))
+
+sys.exit(int(any_invalid))


### PR DESCRIPTION
Adds a GitHub Actions workflow that will check each TOML parser to see if it validates against the 
provided parser schema (only when the `#:schema` directive is at the top of the file). Validation error 
messages can be seen in the GitHub Actions logs at https://github.com/globaldothealth/isaric/actions.
