### PR TITLE
schema update april

### DIFF
--- a/schemas/dev/observation.schema.json
+++ b/schemas/dev/observation.schema.json
@@ -29,6 +29,7 @@
     },
     "phase": {
       "enum": [
+        "pre-admission",
         "admission",
         "study",
         "followup"

--- a/schemas/dev/observation.schema.json
+++ b/schemas/dev/observation.schema.json
@@ -131,6 +131,7 @@
         "other_symptom",
         "oxygen_o2hb",
         "oxygen_saturation_percent",
+        "oxygen_flow_volume_max",
         "pao2",
         "pao2_sample_type",
         "pH",

--- a/schemas/dev/observation.schema.json
+++ b/schemas/dev/observation.schema.json
@@ -104,6 +104,7 @@
         "hepatomegaly",
         "history_of_fever",
         "inability_to_walk",
+        "inability_to_walk_scale",
         "irritability_peadiatrics",
         "joint_pain",
         "loss_of_smell",

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -676,6 +676,7 @@
           "phase": {
             "description": "Phase of study",
             "enum": [
+              "pre-admission",
               "admission",
               "study",
               "followup"
@@ -683,6 +684,7 @@
             "x-taplo": {
               "docs": {
                 "enumValues": [
+                  "Strictly before admission",
                   "Taken at or before admission",
                   "Observation during study period",
                   "Recorded in followup survey"

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -349,6 +349,10 @@
           "description": "Malignant neoplasm",
           "$ref": "#/definitions/mapping"
         },
+        "has_malnutrition": {
+          "description": "Malnutrition",
+          "$ref": "#/definitions/mapping"
+        },
         "has_smoking": {
           "description": "History of smoking",
           "$ref": "#/definitions/mapping"
@@ -810,7 +814,6 @@
               "lower_chest_wall_indrawing",
               "lung_sounds",
               "lymphadenopathy",
-              "malnutrition",
               "muscle_aches",
               "neuromuscular_blocking_agents",
               "renal_replacement_therapy_dialysis",

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -811,6 +811,7 @@
               "hepatomegaly",
               "history_of_fever",
               "inability_to_walk",
+              "inability_to_walk_scale",
               "irritability_peadiatrics",
               "joint_pain",
               "loss_of_smell",

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -231,7 +231,7 @@
       "required": [
         "subject_id",
         "country_iso3",
-        "enrolment_date",
+        "admission_date",
         "age",
         "sex_at_birth",
         "ethnicity",

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -591,6 +591,10 @@
           "description": "Neuraminidase",
           "$ref": "#/definitions/mapping"
         },
+        "treatment_neuromuscular_blocking_agents": {
+          "description": "Neuromuscular blocking agents",
+          "$ref": "#/definitions/mapping"
+        },
         "treatment_oxygen_interface": {
           "description": "Oxygen interface",
           "$ref": "#/definitions/mapping"
@@ -815,7 +819,6 @@
               "lung_sounds",
               "lymphadenopathy",
               "muscle_aches",
-              "neuromuscular_blocking_agents",
               "renal_replacement_therapy_dialysis",
               "runny_nose",
               "seizures",

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -643,10 +643,6 @@
           "description": "Pacing",
           "$ref": "#/definitions/mapping"
         },
-        "treatment_o2_flow_vol_max": {
-          "description": "O2 flow vol max",
-          "$ref": "#/definitions/mapping"
-        },
         "outcome": {
           "description": "Outcome",
           "$ref": "#/definitions/mapping"
@@ -836,6 +832,7 @@
               "other_symptom",
               "oxygen_o2hb",
               "oxygen_saturation_percent",
+              "oxygen_flow_volume_max",
               "pao2",
               "pao2_sample_type",
               "pH",

--- a/schemas/dev/subject.schema.json
+++ b/schemas/dev/subject.schema.json
@@ -170,6 +170,11 @@
       "description": "Malignant neoplasm",
       "category": "comorbidities"
     },
+    "has_malnutrition": {
+      "type": "boolean",
+      "description": "Malnutrition",
+      "category": "comorbidities"
+    },
     "has_smoking": {
       "enum": [
         "yes",

--- a/schemas/dev/subject.schema.json
+++ b/schemas/dev/subject.schema.json
@@ -6,7 +6,7 @@
   "required": [
     "subject_id",
     "country_iso3",
-    "enrolment_date",
+    "admission_date",
     "age",
     "sex_at_birth",
     "ethnicity",

--- a/schemas/dev/visit.schema.json
+++ b/schemas/dev/visit.schema.json
@@ -318,11 +318,6 @@
       "description": "Pacing",
       "category": "treatments"
     },
-    "treatment_o2_flow_vol_max": {
-      "type": "integer",
-      "description": "O2 flow vol max",
-      "category": "treatments"
-    },
     "outcome": {
       "enum": [
         "death",

--- a/schemas/dev/visit.schema.json
+++ b/schemas/dev/visit.schema.json
@@ -244,6 +244,11 @@
       "description": "Neuraminidase",
       "category": "treatments"
     },
+    "treatment_neuromuscular_blocking_agents": {
+      "type": "boolean",
+      "description": "Neuromuscular blocking agents",
+      "category": "treatments"
+    },
     "treatment_oxygen_interface": {
       "type": "boolean",
       "description": "Oxygen interface",


### PR DESCRIPTION
- schemas: split phase admission into phase pre-admission #110
- schemas: make admission, not enrolment_date required #113
- schemas: move treatment o2 flow vol max to observations #108
- schemas: add malnutrition to comorbidities #107
- schemas: add neuromuscular blocking agents to visit  #108
- schemas(observation): add inability_to_walk_scale #104
