### PR TITLE
parsers: remove study table

### DIFF
--- a/isaric/parsers/ccp-ghana.toml
+++ b/isaric/parsers/ccp-ghana.toml
@@ -6,7 +6,6 @@
   defaultDateFormat = "%d/%m/%Y"
 
   [adtl.tables]
-    study = { kind = "constant" }
 
     [adtl.tables.subject]
       kind = "groupBy"
@@ -228,10 +227,6 @@
     194 = "YEM"
     195 = "ZMB"
     196 = "ZWE"
-
-[study]
-  country_iso3 = "GHA"
-  study_id = "ccp-ghana"
 
 [subject]
   pathogen = "COVID-19"

--- a/isaric/parsers/datcov-southafrica.toml
+++ b/isaric/parsers/datcov-southafrica.toml
@@ -4,9 +4,6 @@
   name = "datcov-southafrica"
   description = "South Africa DATCOV study"
 
-  [adtl.tables.study]
-    kind = "constant"
-
   [adtl.tables.subject]
     kind = "oneToOne"
     schema = "../../schemas/dev/subject.schema.json"
@@ -49,11 +46,6 @@
   2 = "Some difficulty"
   3 = "Lots of difficulty"
   4 = "Unable to walk"
-
-[study]
-  id = "datcov-southafrica"
-  date = ""                 # to be filled
-  country_iso3 = "ZAF"
 
 [subject]
   study_id = "datcov-southafrica"
@@ -869,7 +861,7 @@
   phase = "followup"
   date = { field = "flw2_survey_date_{n}" }
   text = { field = "flw2_eq5d_mb_5l_uk_eng_2_{n}", ref = "inabilityWalk" }
-  if.not = {"flw2_eq5d_mb_5l_uk_eng_2_{n}" = ""}
+  if.not = { "flw2_eq5d_mb_5l_uk_eng_2_{n}" = "" }
   for.n.range = [1, 5]
 
 [[observation]]
@@ -877,7 +869,7 @@
   phase = "followup"
   date = { field = "flw2_survey_date_{n}" }
   text = { field = "flw2_walking_today_{n}", ref = "inabilityWalkToday" }
-  if.not = {"flw2_walking_today_{n}" = ""}
+  if.not = { "flw2_walking_today_{n}" = "" }
   for.n.range = [1, 5]
 
 [[observation]]

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -5,7 +5,6 @@
   description = "ISARIC CCPUK study"
 
   [adtl.tables]
-    study = { kind = "constant" }
     subject = { kind = "groupBy", groupBy = "subject_id", aggregation = "lastNotNull", schema = "../../schemas/dev/subject.schema.json" }
     visit = { kind = "groupBy", groupBy = "visit_id", aggregation = "lastNotNull", schema = "../../schemas/dev/visit.schema.json" }
     observation = { kind = "oneToMany", schema = "../../schemas/dev/observation.schema.json", common = { visit_id = { field = "subjid", sensitive = true } } }
@@ -37,11 +36,6 @@
   3 = "Some difficulty"
   4 = "Lots of difficulty"
   5 = "Unable to walk"
-
-[study]
-  id = "isaric-ccpuk"
-  date = "2021-01-01"
-  country_iso3 = "GBR"
 
   ## SUBJECT
 

--- a/isaric/parsers/isaric-ecmo.toml
+++ b/isaric/parsers/isaric-ecmo.toml
@@ -231,14 +231,9 @@
   196 = "ZWE"
 
 [adtl.tables]
-  study = { kind = "constant" }
   subject = { kind = "groupBy", groupBy = "subject_id", aggregation = "lastNotNull", schema = "../../schemas/dev/subject.schema.json" }
   visit = { kind = "groupBy", groupBy = "visit_id", aggregation = "lastNotNull", schema = "../../schemas/dev/visit.schema.json" }
   observation = { kind = "oneToMany", schema = "../../schemas/dev/observation.schema.json", common = { visit_id = { field = "subjid", sensitive = true } } }
-
-[study]
-  id = "isaric-ecmo"
-  country_iso3 = "GBR"
 
 [subject]
   study_id = "isaric-ecmo"

--- a/isaric/parsers/isaric-rapid.toml
+++ b/isaric/parsers/isaric-rapid.toml
@@ -240,13 +240,9 @@
   ]
 
 [adtl.tables]
-  study = { kind = "constant" }
   subject = { kind = "groupBy", groupBy = "subject_id", aggregation = "lastNotNull", schema = "../../schemas/dev/subject.schema.json" }
   visit = { kind = "groupBy", groupBy = "visit_id", aggregation = "lastNotNull", schema = "../../schemas/dev/visit.schema.json" }
   observation = { kind = "oneToMany", schema = "../../schemas/dev/observation.schema.json", common = { visit_id = { field = "subjid", sensitive = true } } }
-
-[study]
-  id = "isaric-rapid"
 
   ## SUBJECT
 
@@ -1538,7 +1534,9 @@
   [observation.context]
     combinedType = "set"
     excludeWhen = "none"
-    fields = [{ field = "oxygen_cmtype", values = { 1 = "Nasal prongs", 2 = "HF nasal cannula", 3 = "Mask", 4 = "Mask with reservoir", 5 = "CPAP/NIV mask" } }]
+    fields = [
+      { field = "oxygen_cmtype", values = { 1 = "Nasal prongs", 2 = "HF nasal cannula", 3 = "Mask", 4 = "Mask with reservoir", 5 = "CPAP/NIV mask" } },
+    ]
 
 [[observation]]
   name = "oxygen_flow_volume_max"
@@ -1553,4 +1551,6 @@
   [observation.context]
     combinedType = "set"
     excludeWhen = "none"
-    fields = [{ field = "daily_oxygen_cmtype", values = { 1 = "Nasal prongs", 2 = "HF nasal cannula", 3 = "Mask", 4 = "Mask with reservoir", 5 = "CPAP/NIV mask" } }]
+    fields = [
+      { field = "daily_oxygen_cmtype", values = { 1 = "Nasal prongs", 2 = "HF nasal cannula", 3 = "Mask", 4 = "Mask with reservoir", 5 = "CPAP/NIV mask" } },
+    ]

--- a/isaric/parsers/western-australia.toml
+++ b/isaric/parsers/western-australia.toml
@@ -4,9 +4,6 @@
   name = "western-australia"
   description = "Western Australian Covid-19 Research Response"
 
-  [adtl.tables.study]
-    kind = "constant"
-
   [adtl.tables.subject]
     kind = "groupBy"
     groupBy = "subject_id"
@@ -39,12 +36,6 @@
     { field = "cestdat", description = "Onset date of first/earliest symptom", source_date = "%d/%m/%Y" },
     { field = "dsstdat", description = "Date of enrolment", source_date = "%d/%m/%Y" },
   ]
-
-
-[study]
-  id = "CVPPNSH"
-  date = ""            # fill here!
-  country_iso3 = "AUS"
 
 [subject]
   study_id = "western-australia" # fill here!


### PR DESCRIPTION
Removes study table, it was only used for metadata, which should
be in the adtl section and not a separate table.
