### PR TITLE
parsers(ccpuk): add RELSUB matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,27 @@ uses it for validation. Validation status (true/false) and error messages are
 reported in the `adtl_valid` and `adtl_error` columns in the output
 respectively.
 
+### Running with RELSUB matching
+
+ISARIC source datasets have unique visit IDs, with every patient assigned a new
+ID on every visit. There is a separate table (RELSUB in SDTM), which matches
+visit IDs for the same subject. So if visit `A012` and `A342` refer to the same
+patient, there would be an entry in the RELSUB table like: `A012,A342,SAME`. For
+datasets that have relsub matching (`ref = "relsub"` present in subject ID
+definition), we need to generate the RELSUB matching definition first, before
+calling adtl with the RELSUB map. As an example, for the CCPUK RELSUB file
+(corresponding [parser](isaric/parsers/isaric-ccpuk.toml)), this is the
+procedure to transform the source data with RELSUB mapping:
+
+```shell
+# Create the RELSUB mapping
+python3 scripts/relsub.py CCPUK_RELSUB.csv -o isaric-ccpuk-relsub.json
+adtl isaric/parsers/isaric-ccpuk.toml ../isaric-data/ccpuk.csv --include-def isaric-ccpuk-relsub.json
+```
+
+The RELSUB script expects the ID columns to be named USUBJID, RSUBJID; these can
+be changed via parameters, see `python3 scripts/relsub.py --help`.
+
 ### Development
 
 Install [pre-commit](https://pre-commit.com) and setup pre-commit hooks

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -43,15 +43,16 @@
   country_iso3 = "GBR"
   pathogen = "COVID-19"
 
+  [subject.subject_id]
+    field = "subjid"
+    ref = "relsub"
+    sensitive = true
+    ignoreMissingKey = true
+
   [subject.sex_at_birth]
     field = "sex"
     description = "Sex at Birth"
     values = { 1 = "male", 2 = "female", 3 = "non_binary" }
-
-  [subject.subject_id]
-    field = "subjid"
-    sensitive = true
-    description = "Participant Identification Number (PIN) specify CPMS Site code (hyphen) four to six digit number patient number e.g. Y0401-0001."
 
   [subject.enrolment_date]
     field = "dsstdat"
@@ -285,6 +286,12 @@
 [visit]
   country_iso3 = "GBR"
 
+  [visit.subject_id]
+    field = "subjid"
+    ref = "relsub"
+    sensitive = true
+    ignoreMissingKey = true
+
   [visit.date_outcome]
     combinedType = "firstNonNull"
     description = "Outcome date"
@@ -292,11 +299,6 @@
 
   [visit.visit_id]
     field = "subjid"
-    sensitive = true
-
-  [visit.subject_id] # same as visit_id!
-    field = "subjid"
-    sensitive = true
 
   [visit.start_date]
     combinedType = "firstNonNull"

--- a/output/ISARIC CCPUK/adtl-output.md
+++ b/output/ISARIC CCPUK/adtl-output.md
@@ -1,14 +1,14 @@
->adtl isaric-ccpuk.toml CCPUKSARILondon_DATA_2022-06-06_1135.csv
+> adtl isaric/parsers/isaric-ccpuk.toml ../isaric-data/isaric-ccpuk/CCPUKSARILondon_DATA_2022-06-06_1135.csv --include-def isaric/parsers/relsub.json
 
-|table          |valid  |total  |percentage_valid|
+|table       	|valid	|total	|percentage_valid|
 |---------------|-------|-------|----------------|
-|subject        |31457  |36754  |85.587963% |
-|visit          |30810  |36754  |83.827611% |
-|observation    |1192364        |1202801        |99.132275% |
+|subject       	|30745	|35753	|85.992784% |
+|visit         	|30810	|36754	|83.827611% |
+|observation   	|1192364	|1202801	|99.132275% |
 
 ## subject
 
-* 5289: data must contain ['subject_id', 'country_iso3', 'admission_date', 'age', 'sex_at_birth', 'ethnicity', 'pathogen'] properties
+* 5000: data must contain ['subject_id', 'country_iso3', 'admission_date', 'age', 'sex_at_birth', 'ethnicity', 'pathogen'] properties
 * 5: data.age must be smaller than or equal to 120
 * 2: data.admission_date must be date
 * 1: data.age must be bigger than or equal to 0
@@ -23,5 +23,5 @@
 ## observation
 
 * 10363: data must contain ['phase', 'date', 'name'] properties
-* 68: data.date must be date
+* 68: data.date cannot be validated by any definition
 * 6: data.value must be number

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -31,6 +31,9 @@
             "if": {
               "type": "object"
             },
+            "ignoreMissingKey": {
+              "const": true
+            },
             "sensitive": {
               "type": "boolean",
               "description": "Indicates to the parser whether the field is sensitive. Usually a sensitive field is hashed or encrypted before storing in the database.",

--- a/schemas/dev/subject.schema.json
+++ b/schemas/dev/subject.schema.json
@@ -14,7 +14,10 @@
   ],
   "properties": {
     "subject_id": {
-      "type": "string",
+      "type": [
+        "string",
+        "integer"
+      ],
       "description": "Unique ID of subject",
       "category": "metadata"
     },

--- a/schemas/dev/visit.schema.json
+++ b/schemas/dev/visit.schema.json
@@ -18,7 +18,10 @@
       "category": "metadata"
     },
     "subject_id": {
-      "type": "string",
+      "type": [
+        "string",
+        "integer"
+      ],
       "description": "Unique ID of subject",
       "category": "metadata"
     },

--- a/scripts/relsub.py
+++ b/scripts/relsub.py
@@ -101,7 +101,7 @@ def main():
         delimiter=args.delimiter,
     )
     with open(args.output, "w") as fp:
-        json.dump(matches, fp, indent=2, sort_keys=True)
+        json.dump({"relsub": {"values": matches}}, fp, indent=2, sort_keys=True)
     print("relsub.py: wrote", args.output)
     print(
         f"           {len(set(matches.values()))} unique IDs across {len(matches)} total"


### PR DESCRIPTION
- scripts(relsub): alter output to be used with --include-def
- schemas: allow subject ID to be integer
- parsers(ccpuk): use relsub for subject ID
- docs: add howto for RELSUB matching
