### PR TITLE
schemas: use range limits and type check for observations table

### DIFF
--- a/.github/workflows/parsers.yml
+++ b/.github/workflows/parsers.yml
@@ -7,12 +7,14 @@ on:
     - 'isaric/parsers/*.toml'
     - 'ci/validate_parser.py'
     - '.github/workflows/parsers.yml'
+    - 'schemas/*/*.json'
   pull_request:
     branches: [ main ]
     paths:
     - 'isaric/parsers/*.toml'
     - 'ci/validate_parser.py'
     - '.github/workflows/parsers.yml'
+    - 'schemas/*/*.json'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/schemas.yml
+++ b/.github/workflows/schemas.yml
@@ -1,0 +1,40 @@
+name: schemas
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - 'scripts/test-schemas/*.py'
+    - 'schemas/dev/*.json'
+    - '.github/workflows/schemas.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+    - 'scripts/test-schemas/*.py'
+    - 'schemas/dev/*.json'
+    - '.github/workflows/schemas.yml'
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Lint with flake8
+      run: |
+        python3 -m pip install flake8 pytest
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 scripts/test-schemas --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 scripts/test-schemas --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Install dependencies
+      run: |
+        python3 -m pip install -r scripts/test-schemas/requirements.txt
+    - name: Test with pytest
+      run: |
+        python3 -m pytest scripts/test-schemas/

--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -6,11 +6,13 @@ on:
     paths:
     - 'scripts/**.py'
     - '.github/workflows/scripts.yml'
+    - '!scripts/test-schemas/**'
   pull_request:
     branches: [ main ]
     paths:
     - 'scripts/**.py'
     - '.github/workflows/scripts.yml'
+    - '!scripts/test-schemas/**'
   workflow_dispatch:
 
 jobs:
@@ -38,4 +40,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        python3 -m pytest -vv
+        python3 -m pytest -vv --ignore=test-schemas

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -673,8 +673,8 @@ into the subtypes for the phase. For example:
 Other fields
 ~~~~~~~~~~~~
 
-**avpu**: Text. Where is the subject on the AVPU consciousness scale
-(Alert, Voice, Pain, Unresponsive)
+**avpu**: Text. Where is the subject on the AVPU consciousness scale, one of
+*Alert, Voice, Pain, Unresponsive*.
 
 **abdominal_pain**: Bool.
 
@@ -697,7 +697,7 @@ described as bleeding (haemorrhage) or similar, use
 **clinical_classification_critical_illness_scale**: Currently Unused.
 Traffic-light suggests only in one parser, suggest editing or removal.
 
-**clinical_frailty_score**: Value. `Frailty
+**clinical_frailty_score**: Value (1-9). `Frailty
 scale <https://www.bgs.org.uk/sites/default/files/content/attachment/2018-07-05/rockwood_cfs.pdf>`__
 
 .. _confusion:
@@ -710,11 +710,11 @@ scale <https://www.bgs.org.uk/sites/default/files/content/attachment/2018-07-05/
 
 **diarrhoea**: Bool.
 
-**diastolic_blood_pressure_mmHg**: Value.
+**diastolic_blood_pressure_mmHg**: Value (50-250).
 
-**systolic_blood_pressure_mmHg**: Value.
+**systolic_blood_pressure_mmHg**: Value (50-250).
 
-**mean_arterial_blood_pressure_mmHg**: Value.
+**mean_arterial_blood_pressure_mmHg**: Value (50-250).
 
 **ear_pain**: Bool.
 
@@ -722,12 +722,12 @@ scale <https://www.bgs.org.uk/sites/default/files/content/attachment/2018-07-05/
 
 **feeding_intolerance_pediatrics** Bool. Unused.
 
-**glasgow_coma_score**: Value. `Coma
+**glasgow_coma_score**: Value (3-15). `Coma
 scale <https://www.glasgowcomascale.org>`__
 
 **headache**: Bool.
 
-**heart_rate_bpm**: Value.
+**heart_rate_bpm**: Value (1-250).
 
 **heart_sounds**: Bool.
 
@@ -745,13 +745,13 @@ inability_to_walk_scale_
 .. _inability_to_walk_scale:
 
 **inability_to_walk_scale**: Use a 1-4 scale to indicate the degree of
-difficulty a subject has walking. Values should map to: *1-No
-difficulty, 2-Some difficulty, 3-Lots of difficulty, 4-Unable to walk*.
+difficulty a subject has walking. Values should map to integers 1-4: 1 (No
+difficulty), 2 (Some difficulty), 3 (Lots of difficulty), 4 (Unable to walk).
 If the field contains a greater number of options, they should be mapped
 onto a 1-4 scale, rounding down. E.g., for a 1-5 scale of: *1-no
 inability, 2-slight inability, 3-moderate inability, 4-severe inability,
 5-unable*, option 3 (moderate inability) should be rounded down and
-mapped to *2-some difficulty* in the 1-4 scale. If a relevant field
+mapped to 2 in the 1-4 scale. If a relevant field
 instead contains a boolean Y/N response, use inability_to_walk_ instead.
 
 **irritability_pediatrics**: Bool. Unused.
@@ -772,7 +772,7 @@ combined.
 
 **lymphadenopathy**: Bool. Combines adenopathy and lymphadenopathy.
 
-**mid_upper_arm_circumference_cm**: Value.
+**mid_upper_arm_circumference_cm**: Value (5-100).
 
 **muscle_aches**: Bool.
 
@@ -784,17 +784,17 @@ fields describing symptoms, here.
 **oxygen_flow_volume_max**: Value. If the subject received O2 therapy,
 record the maximum flow volume.
 
-**oxygen_saturation_percent**: Value. Use context to note whether
+**oxygen_saturation_percent**: Value (50-100). Use context to note whether
 observation was made on room air, on while on oxygen.
 
-**pao2_mmHg**: Value. Use context to record whether this is an arterial,
+**pao2_mmHg**: Value (50-150). Use context to record whether this is an arterial,
 venous or capillary measurement if data is provided. Use mmHg as the
 default unit.
 
-**pco2_mmHg**: Value. Use context to note if this is from the same blood
+**pco2_mmHg**: Value (10-100). Use context to note if this is from the same blood
 gas record as the *pao2*/*pH* observation.
 
-**pH**: Value. Use context to note if this is from the same blood gas
+**pH**: Value (4-10). Use context to note if this is from the same blood gas
 record as the *pao2*/*pco2* observation.
 
 **pneumonia**: Bool. Use context to note if bacterial, viral or COP, and
@@ -802,11 +802,11 @@ if the patient requires oxygen as a result (if specified in that field,
 don’t assume that if the patient is recorded as being on oxygen
 elsewhere, it is related to this record of pneumonia).
 
-**respiratory_rate**: Value.
+**respiratory_rate**: Value (1-50).
 
-**richmond_agitation-sedation_scale**: Value.
+**richmond_agitation-sedation_scale**: Value (-5 to 4, including 0).
 
-**riker_sedation-agitation_scale**: Value.
+**riker_sedation-agitation_scale**: Value (1-7).
 
 **runny_nose**: Bool.
 
@@ -826,7 +826,7 @@ elsewhere, it is related to this record of pneumonia).
 conditional statements if the refill time is given rather than a yes/no
 response.
 
-**temperature_celsius**: Value
+**temperature_celsius**: Value (25-50)
 
 **total_fluid_output_ml**: Value.
 

--- a/isaric/parsers/ccp-ghana.toml
+++ b/isaric/parsers/ccp-ghana.toml
@@ -860,21 +860,21 @@
   phase = "pre-admission"
   date = { ref = "admissionDateHierarchy" }
 
-  [observation.value]
+  [observation.text]
     field = "adm21s2"
     description = "AVPU: responsiveness scale:"
 
     [observation.value.values]
-      1 = "alert"
-      2 = "verbal_stimulation"
-      3 = "painful_stimulation"
-      4 = "unresponsive"
+      1 = "Alert"
+      2 = "Verbal"
+      3 = "Pain"
+      4 = "Unresponsive"
 
 [[observation]]
   name = "base_excess"
   phase = "study"
   date = { field = "icu_date" }
-  text = { field = "base_excess", description = "Base excess" }
+  value = { field = "base_excess", description = "Base excess" }
 
 [[observation]]
   name = "bleeding_haemorrhage"

--- a/isaric/parsers/datcov-southafrica.toml
+++ b/isaric/parsers/datcov-southafrica.toml
@@ -35,17 +35,17 @@
   ]
 
 [adtl.defs.inabilityWalk.values]
-  1 = "No difficulty"
-  2 = "Some difficulty"
-  3 = "Some difficulty"
-  4 = "Lots of difficulty"
-  5 = "Unable to walk"
+  1 = 1 # "No difficulty"
+  2 = 2 # "Some difficulty"
+  3 = 2 # "Some difficulty"
+  4 = 3 # "Lots of difficulty"
+  5 = 4 # "Unable to walk"
 
 [adtl.defs.inabilityWalkToday.values]
-  1 = "No difficulty"
-  2 = "Some difficulty"
-  3 = "Lots of difficulty"
-  4 = "Unable to walk"
+  1 = 1 # "No difficulty"
+  2 = 2 # "Some difficulty"
+  3 = 3 # "Lots of difficulty"
+  4 = 4 # "Unable to walk"
 
 [subject]
   # study_id = "datcov-southafrica"
@@ -913,19 +913,19 @@
   date = { field = "flw_survey_date" }
   name = "inability_to_walk_scale"
   phase = "followup"
-  text = { field = "flw_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
+  value = { field = "flw_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
 
 [[observation]]
   date = { field = "flw_survey_date" }
   name = "inability_to_walk_scale"
   phase = "followup"
-  text = { field = "flw_walking_today", ref = "inabilityWalkToday" }
+  value = { field = "flw_walking_today", ref = "inabilityWalkToday" }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { field = "flw2_survey_date_{n}" }
-  text = { field = "flw2_eq5d_mb_5l_uk_eng_2_{n}", ref = "inabilityWalk" }
+  value = { field = "flw2_eq5d_mb_5l_uk_eng_2_{n}", ref = "inabilityWalk" }
   if.not = { "flw2_eq5d_mb_5l_uk_eng_2_{n}" = "" }
   for.n.range = [1, 5]
 
@@ -933,7 +933,7 @@
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { field = "flw2_survey_date_{n}" }
-  text = { field = "flw2_walking_today_{n}", ref = "inabilityWalkToday" }
+  value = { field = "flw2_walking_today_{n}", ref = "inabilityWalkToday" }
   if.not = { "flw2_walking_today_{n}" = "" }
   for.n.range = [1, 5]
 

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -31,11 +31,11 @@
   ]
 
 [adtl.defs.inabilityWalk.values]
-  1 = "No difficulty"
-  2 = "Some difficulty"
-  3 = "Some difficulty"
-  4 = "Lots of difficulty"
-  5 = "Unable to walk"
+  1 = 1 # "No difficulty"
+  2 = 2 # "Some difficulty"
+  3 = 2 # "Some difficulty"
+  4 = 3 # "Lots of difficulty"
+  5 = 4 # "Unable to walk"
 
   ## SUBJECT
 
@@ -888,7 +888,7 @@
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
 
-  [observation.text]
+  [observation.value]
     combinedType = "firstNonNull"
     fields = [
       { field = "flw_eq5d_mb_p", ref = "inabilityWalk" },
@@ -961,7 +961,7 @@
   name = "base_excess"
   phase = "study"
   date = { field = "daily_dsstdat", description = "Date of assessment" }
-  is_present = { field = "daily_baseex_lborres", ref = "Y/N/NK" }
+  value = { field = "daily_baseex_lborres" }
 
 [[observation]]
   name = "sternal_capillary_refill_time_greater_2s"

--- a/isaric/parsers/isaric-rapid.toml
+++ b/isaric/parsers/isaric-rapid.toml
@@ -18,11 +18,11 @@
     7 = "Latin_American"
 
   [adtl.defs.inabilityWalk.values]
-    1 = "No difficulty"
-    2 = "Some difficulty"
-    3 = "Some difficulty"
-    4 = "Lots of difficulty"
-    5 = "Unable to walk"
+    1 = 1 # "No difficulty"
+    2 = 2 # "Some difficulty"
+    3 = 2 # "Some difficulty"
+    4 = 3 # "Lots of difficulty"
+    5 = 4 # "Unable to walk"
 
   [adtl.defs.countryMap.values]
     1 = "AFG"
@@ -1429,31 +1429,31 @@
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  text = { field = "flw_eq5d_mb_5l_uk_eng", ref = "inabilityWalk" }
+  value = { field = "flw_eq5d_mb_5l_uk_eng", ref = "inabilityWalk" }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  text = { field = "flw_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
-
-[[observation]]
-  name = "inability_to_walk"
-  phase = "followup"
-  date = { ref = "followupDateHierarchy" }
-  text = { field = "flw_walking_today", values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
+  value = { field = "flw_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  text = { field = "flw2_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
+  value = { field = "flw_walking_today" } #, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  text = { field = "flw2_walking_today", values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
+  value = { field = "flw2_eq5d_mb_5l_uk_eng_2", ref = "inabilityWalk" }
+
+[[observation]]
+  name = "inability_to_walk_scale"
+  phase = "followup"
+  date = { ref = "followupDateHierarchy" }
+  value = { field = "flw2_walking_today" }#, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
 
 [[observation]]
   name = "clinical_frailty_score"
@@ -1508,7 +1508,7 @@
   name = "base_excess"
   phase = "study"
   date = { field = "ccm_a_dat" }
-  is_present = { field = "ccm_a_baseex_lborres", values = { 1 = true } }
+  value = { field = "ccm_a_baseex_lborres" }
 
 [[observation]]
   name = "oxygen_flow_volume_max"

--- a/isaric/parsers/western-australia.toml
+++ b/isaric/parsers/western-australia.toml
@@ -43,11 +43,11 @@
   ]
 
 [adtl.defs.inabilityWalk.values]
-  1 = "No difficulty"
-  2 = "Some difficulty"
-  3 = "Some difficulty"
-  4 = "Lots of difficulty"
-  5 = "Unable to walk"
+  1 = 1 # "No difficulty"
+  2 = 2 # "Some difficulty"
+  3 = 2 # "Some difficulty"
+  4 = 3 # "Lots of difficulty"
+  5 = 4 # "Unable to walk"
 
 [subject]
   pathogen = "COVID-19"
@@ -910,13 +910,13 @@
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { field = "dsstdtc" }                                           # Can't find a date for the followup forms specifically
-  text = { field = "basline_mobility_discharge", ref = "inabilityWalk" }
+  value = { field = "basline_mobility_discharge", ref = "inabilityWalk" }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { field = "dsstdtc" }                                                    # Can't find a date for the followup forms specifically
-  text = { field = "basline_mobility_discharge_followup", ref = "inabilityWalk" }
+  value = { field = "basline_mobility_discharge_followup", ref = "inabilityWalk" }
 
 [[observation]]
   name = "temperature_celsius"

--- a/schemas/dev/observation.schema.json
+++ b/schemas/dev/observation.schema.json
@@ -12,17 +12,326 @@
     {
       "required": [
         "text"
-      ]
+      ],
+      "properties": {
+        "name": {
+          "const": "avpu"
+        },
+        "text": {
+          "enum": [
+            "Alert",
+            "Verbal",
+            "Pain",
+            "Unresponsive"
+          ]
+        }
+      }
+    },
+    {
+      "$comment": "Oxygen flow volume is represented as a range which is not a native JSON Schema type",
+      "required": [
+        "text"
+      ],
+      "properties": {
+        "name": {
+          "const": "oxygen_flow_volume_max"
+        }
+      }
     },
     {
       "required": [
         "value"
-      ]
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "clinical_classification_critical_illness_scale",
+            "total_fluid_output_ml",
+            "base_excess",
+            "oxygen_o2hb"
+          ]
+        },
+        "value": {
+          "type": "number"
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "clinical_frailty_score"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 9
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "inability_to_walk_scale"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "glasgow_coma_score"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 3,
+          "maximum": 15
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "heart_rate_bpm"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 250
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "mid_upper_arm_circumference_cm"
+        },
+        "value": {
+          "type": "number",
+          "minimum": 5,
+          "maximum": 100
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "oxygen_saturation_percent"
+        },
+        "value": {
+          "type": "number",
+          "minimum": 50,
+          "maximum": 100
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "pao2_mmHg"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 50,
+          "maximum": 150
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "pco2_mmHg"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 10,
+          "maximum": 100
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "pH"
+        },
+        "value": {
+          "type": "number",
+          "minimum": 4,
+          "maximum": 10
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "respiratory_rate"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 50
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "richmond_agitation-sedation_scale"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": -5,
+          "maximum": 4
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "riker_sedation-agitation_scale"
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 7
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "const": "temperature_celsius"
+        },
+        "value": {
+          "type": "number",
+          "minimum": 25,
+          "maximum": 50
+        }
+      }
+    },
+    {
+      "required": [
+        "text"
+      ],
+      "properties": {
+        "name": {
+          "const": "other_symptom"
+        }
+      }
+    },
+    {
+      "required": [
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "diastolic_blood_pressure_mmHg",
+            "mean_arterial_blood_pressure_mmHg",
+            "systolic_blood_pressure_mmHg"
+          ]
+        },
+        "value": {
+          "type": "integer",
+          "minimum": 50,
+          "maximum": 250
+        }
+      }
     },
     {
       "required": [
         "is_present"
-      ]
+      ],
+      "properties": {
+        "name": {
+          "enum": [
+            "pneumonia",
+            "abdominal_pain",
+            "altered_consciousness_confusion",
+            "anorexia",
+            "bleeding",
+            "bleeding_haemorrhage",
+            "chest_pain",
+            "confusion",
+            "conjunctivitis",
+            "cough",
+            "cough_dry",
+            "cough_with_haemoptysis",
+            "cough_with_sputum_production",
+            "cyanosis",
+            "diarrhoea",
+            "ear_pain",
+            "fatigue_malaise",
+            "feeding_intolerance_pediatrics",
+            "headache",
+            "hepatomegaly",
+            "history_of_fever",
+            "inability_to_walk",
+            "irritability_pediatrics",
+            "joint_pain",
+            "loss_of_smell",
+            "loss_of_taste",
+            "loss_of_smell_or_taste",
+            "lower_chest_wall_indrawing",
+            "lung_sounds",
+            "lymphadenopathy",
+            "muscle_aches",
+            "runny_nose",
+            "seizures",
+            "severe_dehydration",
+            "shortness_of_breath",
+            "skin_rash",
+            "skin_ulcers",
+            "sore_throat",
+            "sternal_capillary_refill_time_greater_2s",
+            "vomiting_nausea",
+            "wheezing",
+            "heart_sounds"
+          ]
+        }
+      }
     }
   ],
   "properties": {
@@ -104,76 +413,6 @@
       },
       "uniqueItems": true,
       "description": "Context that qualifies the observation, e.g. *axillary* temperature, or *room air* oxygen saturation measurement"
-    },
-    "name": {
-      "enum": [
-        "avpu",
-        "clinical_classification_critical_illness_scale",
-        "pneumonia",
-        "clinical_frailty_score",
-        "diastolic_blood_pressure_mmHg",
-        "glasgow_coma_score",
-        "abdominal_pain",
-        "altered_consciousness_confusion",
-        "anorexia",
-        "base_excess",
-        "bleeding",
-        "bleeding_haemorrhage",
-        "chest_pain",
-        "confusion",
-        "conjunctivitis",
-        "cough",
-        "cough_dry",
-        "cough_with_haemoptysis",
-        "cough_with_sputum_production",
-        "cyanosis",
-        "diarrhoea",
-        "ear_pain",
-        "fatigue_malaise",
-        "feeding_intolerance_pediatrics",
-        "headache",
-        "hepatomegaly",
-        "history_of_fever",
-        "inability_to_walk",
-        "inability_to_walk_scale",
-        "irritability_pediatrics",
-        "joint_pain",
-        "loss_of_smell",
-        "loss_of_taste",
-        "loss_of_smell_or_taste",
-        "lower_chest_wall_indrawing",
-        "lung_sounds",
-        "lymphadenopathy",
-        "muscle_aches",
-        "runny_nose",
-        "seizures",
-        "severe_dehydration",
-        "shortness_of_breath",
-        "skin_rash",
-        "skin_ulcers",
-        "sore_throat",
-        "sternal_capillary_refill_time_greater_2s",
-        "vomiting_nausea",
-        "wheezing",
-        "heart_rate_bpm",
-        "heart_sounds",
-        "mean_arterial_blood_pressure_mmHg",
-        "mid_upper_arm_circumference_cm",
-        "other_symptom",
-        "oxygen_o2hb",
-        "oxygen_saturation_percent",
-        "oxygen_flow_volume_max",
-        "pao2_mmHg",
-        "pco2_mmHg",
-        "pH",
-        "respiratory_rate",
-        "richmond_agitation-sedation_scale",
-        "riker_sedation-agitation_scale",
-        "systolic_blood_pressure_mmHg",
-        "temperature_celsius",
-        "total_fluid_output_ml"
-      ],
-      "description": "Observation name"
     }
   },
   "dependencies": {

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -704,27 +704,111 @@
       "type": "array",
       "items": {
         "type": "object",
-        "additionalProperties": false,
+        "additionalProperties": true,
         "required": [
           "phase",
-          "name",
           "date"
         ],
         "oneOf": [
           {
             "required": [
-              "text"
-            ]
+              "text",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "enum": [
+                  "other_symptom",
+                  "avpu",
+                  "oxygen_flow_volume_max"
+                ]
+              }
+            }
           },
           {
             "required": [
-              "value"
-            ]
+              "value",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "enum": [
+                  "clinical_frailty_score",
+                  "diastolic_blood_pressure_mmHg",
+                  "glasgow_coma_score",
+                  "base_excess",
+                  "inability_to_walk_scale",
+                  "heart_rate_bpm",
+                  "mean_arterial_blood_pressure_mmHg",
+                  "mid_upper_arm_circumference_cm",
+                  "oxygen_o2hb",
+                  "oxygen_saturation_percent",
+                  "pao2_mmHg",
+                  "pco2_mmHg",
+                  "pH",
+                  "respiratory_rate",
+                  "richmond_agitation-sedation_scale",
+                  "riker_sedation-agitation_scale",
+                  "systolic_blood_pressure_mmHg",
+                  "temperature_celsius",
+                  "total_fluid_output_ml"
+                ]
+              }
+            }
           },
           {
             "required": [
-              "is_present"
-            ]
+              "is_present",
+              "name"
+            ],
+            "properties": {
+              "name": {
+                "enum": [
+                  "pneumonia",
+                  "abdominal_pain",
+                  "altered_consciousness_confusion",
+                  "anorexia",
+                  "bleeding",
+                  "bleeding_haemorrhage",
+                  "chest_pain",
+                  "confusion",
+                  "conjunctivitis",
+                  "cough",
+                  "cough_dry",
+                  "cough_with_haemoptysis",
+                  "cough_with_sputum_production",
+                  "cyanosis",
+                  "diarrhoea",
+                  "ear_pain",
+                  "fatigue_malaise",
+                  "feeding_intolerance_pediatrics",
+                  "headache",
+                  "hepatomegaly",
+                  "history_of_fever",
+                  "inability_to_walk",
+                  "irritability_pediatrics",
+                  "joint_pain",
+                  "loss_of_smell",
+                  "loss_of_taste",
+                  "loss_of_smell_or_taste",
+                  "lower_chest_wall_indrawing",
+                  "lung_sounds",
+                  "lymphadenopathy",
+                  "muscle_aches",
+                  "runny_nose",
+                  "seizures",
+                  "severe_dehydration",
+                  "shortness_of_breath",
+                  "skin_rash",
+                  "skin_ulcers",
+                  "sore_throat",
+                  "sternal_capillary_refill_time_greater_2s",
+                  "vomiting_nausea",
+                  "wheezing",
+                  "heart_sounds"
+                ]
+              }
+            }
           }
         ],
         "properties": {
@@ -833,77 +917,6 @@
               {
                 "$ref": "#/definitions/mapping"
               }
-            ]
-          },
-          "name": {
-            "description": "Observation name",
-            "enum": [
-              "avpu",
-              "clinical_classification_critical_illness_scale_",
-              "pneumonia",
-              "clinical_frailty_score",
-              "diastolic_blood_pressure_mmHg",
-              "glasgow_coma_score",
-              "abdominal_pain",
-              "adenopathy",
-              "altered_consciousness_confusion",
-              "anorexia",
-              "base_excess",
-              "bleeding",
-              "bleeding_haemorrhage",
-              "chest_pain",
-              "confusion",
-              "conjunctivitis",
-              "cough",
-              "cough_dry",
-              "cough_with_haemoptysis",
-              "cough_with_sputum_production",
-              "cyanosis",
-              "diarrhoea",
-              "ear_pain",
-              "fatigue_malaise",
-              "feeding_intolerance_pediatrics",
-              "headache",
-              "hepatomegaly",
-              "history_of_fever",
-              "inability_to_walk",
-              "inability_to_walk_scale",
-              "irritability_pediatrics",
-              "joint_pain",
-              "loss_of_smell",
-              "loss_of_taste",
-              "loss_of_smell_or_taste",
-              "lower_chest_wall_indrawing",
-              "lung_sounds",
-              "lymphadenopathy",
-              "muscle_aches",
-              "runny_nose",
-              "seizures",
-              "severe_dehydration",
-              "shortness_of_breath",
-              "skin_rash",
-              "skin_ulcers",
-              "sore_throat",
-              "sternal_capillary_refill_time_greater_2s",
-              "vomiting_nausea",
-              "wheezing",
-              "heart_rate_bpm",
-              "heart_sounds",
-              "mean_arterial_blood_pressure_mmHg",
-              "mid_upper_arm_circumference_cm",
-              "other_symptom",
-              "oxygen_o2hb",
-              "oxygen_saturation_percent",
-              "oxygen_flow_volume_max",
-              "pao2_mmHg",
-              "pco2_mmHg",
-              "pH",
-              "respiratory_rate",
-              "richmond_agitation-sedation_scale",
-              "riker_sedation-agitation_scale",
-              "systolic_blood_pressure_mmHg",
-              "temperature_celsius",
-              "total_fluid_output_ml"
             ]
           }
         }

--- a/scripts/test-schemas/requirements.txt
+++ b/scripts/test-schemas/requirements.txt
@@ -1,0 +1,1 @@
+fastjsonschema

--- a/scripts/test-schemas/test_schemas.py
+++ b/scripts/test-schemas/test_schemas.py
@@ -1,0 +1,84 @@
+"""
+Test schemas.
+"""
+import json
+from pathlib import Path
+
+import fastjsonschema
+import pytest
+
+SCHEMA_PATH = Path("schemas/dev")
+
+
+def load_schema(path: str):
+    with (SCHEMA_PATH / path).open() as fp:
+        return fastjsonschema.compile(json.load(fp))
+
+
+validate_observation = load_schema("observation.schema.json")
+
+INVALID_OBSERVATIONS = [
+    {
+        "date": "2022-05-05",
+        "name": "respiratory_rate",
+        "phase": "study",
+        "text": "good",
+    },
+    {"date": "2022-05-05", "name": "avpu", "phase": "study", "text": "alert"},
+    {
+        "date": "2022-05-05",
+        "name": "inability_to_walk_scale",
+        "phase": "study",
+        "text": "alert",
+    },
+    {
+        "date": "2022-05-05",
+        "name": "inability_to_walk_scale",
+        "phase": "study",
+        "value": 5,
+    },
+    {
+        "date": "2022-05-05",
+        "name": "richmond_agitation-sedation_scale",
+        "phase": "study",
+        "value": -6,
+    },
+    {"date": "2022-05-05", "name": "headache", "phase": "study", "value": -6},
+    {"date": "2022-05-05", "name": "headache", "phase": "study", "is_present": -6},
+]
+VALID_OBSERVATIONS = [
+    {"date": "2022-05-05", "name": "respiratory_rate", "phase": "study", "value": 20},
+    {"date": "2022-05-05", "name": "avpu", "phase": "study", "text": "Alert"},
+    {
+        "date": "2022-05-05",
+        "name": "inability_to_walk_scale",
+        "phase": "study",
+        "value": 4,
+    },
+    {
+        "date": "2022-05-05",
+        "name": "richmond_agitation-sedation_scale",
+        "phase": "study",
+        "value": 0,
+    },
+    {"date": "2022-05-05", "name": "headache", "phase": "study", "is_present": True},
+    # Additional properties are allowed as long as the required properties are present
+    {
+        "date": "2022-05-05",
+        "name": "headache",
+        "phase": "study",
+        "is_present": True,
+        "text": "Migraine",
+    },
+]
+
+
+@pytest.mark.parametrize("value", INVALID_OBSERVATIONS)
+def test_invalid_observations(value):
+    with pytest.raises(fastjsonschema.JsonSchemaException):
+        validate_observation(value)
+
+
+@pytest.mark.parametrize("value", VALID_OBSERVATIONS)
+def test_valid_observations(value):
+    validate_observation(value)


### PR DESCRIPTION
This PR implements #156. Observations are typed and the parser validation in VSCode will show an error if there is a type mismatch. Currently the schema allows additional fields to be defined, so it is possible to have a `cough` field that has `is_present` but also has `text` set.

For data validation, types and ranges are checked. I have tried to assign ranges that should not be exceeded, some of them may be too wide :)

There is a new schema test suite that currently only checks the observation schema to ensure that validation is performing as expected.