### PR TITLE
scripts(data_summary): modify to include parser, output to subfolder

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -13,6 +13,7 @@ of non-empty fields. The output is in JSON in the following format:
 {
     "file": "CVOLRQ Antarctica 2023-04-05.csv"
     "sha256": "a98942bbcccdde9898924989901293aa111ff",
+    "parser": "isaric/parsers/antarctica.toml",
     "mimetype": "text/csv",
     "encoding": "utf-8-sig",
     "id_field": "record_id",
@@ -28,10 +29,12 @@ of non-empty fields. The output is in JSON in the following format:
 The script requires only Python and can be run as
 
 ```shell
-python3 scripts/data_summary.py <file> <id-field> [--encoding <encoding>]
+python3 scripts/data_summary.py <parser path> <file> <id-field> [--encoding <encoding>]
 ```
 
 An optional `--encoding` flag can be used if the auto-detection of encoding fails.
+The output is also stored in a `metadata` folder under a parser subfolder; this
+folder can be changed by passing the `-o` (`--output-folder`) option.
 
 ## `relsub.py`: REDCap RELSUB matcher
 

--- a/scripts/test_data_summary.py
+++ b/scripts/test_data_summary.py
@@ -8,10 +8,13 @@ TEST_DATA = "test_data.csv"
 
 
 def test_data_summary():
-    assert main(TEST_DATA, id_field="record_id") == dict(
+    assert main(
+        TEST_DATA, parser_name="isaric/parsers/parser.toml", id_field="record_id"
+    ) == dict(
         encoding="utf-8-sig",
         file="test_data.csv",
         id_field="record_id",
+        parser="isaric/parsers/parser.toml",
         mimetype="text/csv",
         n_id=2,
         non_empty_fields=["diabetes_mhyn", "record_id", "renal_mhyn"],


### PR DESCRIPTION
The parser path now needs to be specified, this way the output
JSON has all the information to start a new adtl run. By default
output files will be stored in a parser subfolder under `metadata`.
