### PR TITLE
Adding DoB to main branch parsers

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -332,16 +332,31 @@ Subject
 **subject_id**: Text. Unique ID for the subject (NOTE: currently this is
 the same as the visit ID, prior to implementation of RELSUB matching).
 
-**dataset_id**: Text. Refers to the specifc ID/Version of the dataset
-being used (NOTE TO DEVS: should this be study metadata instead?)
-
 **enrolment_date**: Date. Date of subject enrolment into the study.
 
 **earliest_admission_date**: Date. Date of admission for the first study
 visit. Use ``combinedType = "min"`` To allow the earliest date to be
 chosen from across multiple visits.
 
-**age**: Value. Age of the subject in years.
+**age**: Value. Age of the subject in years. Provided age should be used where
+possible, if not present age can be estimated from the date of birth and admission
+date. Where age is provided as months/days, it will be converted to years such that
+6 months = 0.5 years, 7 days = 0.02 years.
+
+**date_of_birth**: Text. Date of birth in yyyy-mm-dd format. Should only be
+filled if provided in the data, not calculated.
+
+**dob_year**: Value. 4-digit year of birth. Should be filled from the date of
+birth if provided, otherwise can be calculated from age and admission date. As
+year can be estimated, if date_of_birth is blank there is a +/- 1 year error margin.
+
+**dob_month**: Value. Month of birth. Should be filled using the date of birth
+if provided, otherwise can be calculated from age *if provided in months* and
+and admission date. If age is provided in years, the month cannot be accurately
+estimated and should therefore be left blank.
+
+**dob_day**: Value. Day of birth. Should only be filled if a date of birth is
+provided, otherwise left blank.
 
 **sex_at_birth**: Text. One of
 

--- a/isaric/parsers/ccp-drc.toml
+++ b/isaric/parsers/ccp-drc.toml
@@ -89,8 +89,16 @@
     ]
 
   [subject.dob_month]
-    field = "dob"
-    apply = { function = "splitDate", params = ["month"] }
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "month",
+      ] } },
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%Y-%m-%d",
+      ] } },
+    ]
 
   [subject.dob_day]
     field = "dob"

--- a/isaric/parsers/ccp-drc.toml
+++ b/isaric/parsers/ccp-drc.toml
@@ -77,12 +77,36 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "year",
+        2022,
       ] } },
-      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if.any = [
+        { age_unit = 1 },
+        { age_unit = "" },
+      ], apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$fever_date",
+          "$fatigue_date",
+          "$dyspnea_date",
+          "$anosmia_date",
+          "$sore_throat_date",
+          # "$headache_date",
+          # "$signs_symps_date",
+        ],
+        2022,
       ] } },
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$fever_date",
+          "$fatigue_date",
+          "$dyspnea_date",
+          "$anosmia_date",
+          "$sore_throat_date",
+          # "$headache_date",
+          # "$signs_symps_date",
+        ],
+        2022,
         "%Y-%m-%d",
         "months",
       ] } },
@@ -93,16 +117,27 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "month",
+        2022,
       ] } },
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        [
+          "$add_date",
+          "$fever_date",
+          "$fatigue_date",
+          "$dyspnea_date",
+          "$anosmia_date",
+          "$sore_throat_date",
+          # "$headache_date",
+          # "$signs_symps_date",
+        ],
+        2022,
         "%Y-%m-%d",
       ] } },
     ]
 
   [subject.dob_day]
     field = "dob"
-    apply = { function = "splitDate", params = ["day"] }
+    apply = { function = "splitDate", params = ["day", 2022] }
 
   [subject.ethnicity]
     description = "race/ethnicity"

--- a/isaric/parsers/ccp-drc.toml
+++ b/isaric/parsers/ccp-drc.toml
@@ -69,6 +69,33 @@
     description = "Age"
     source_unit = { field = "age_unit", unit = "years", values = { 1 = "years", 2 = "months", 3 = "days" } }
 
+  [subject.date_of_birth]
+    field = "dob"
+
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "year",
+      ] } },
+      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age",
+      ] } },
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age",
+        "%Y-%m-%d",
+        "months",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    field = "dob"
+    apply = { function = "splitDate", params = ["month"] }
+
+  [subject.dob_day]
+    field = "dob"
+    apply = { function = "splitDate", params = ["day"] }
+
   [subject.ethnicity]
     description = "race/ethnicity"
     combinedType = "set"

--- a/isaric/parsers/ccp-ghana.toml
+++ b/isaric/parsers/ccp-ghana.toml
@@ -248,10 +248,15 @@
     field = "recruit_date"
 
   [subject.age]
-    field = "age"
-    description = "Age"
-    source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
-    unit = "years"
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "age", description = "Age", source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }, unit = "years" },
+      { field = "dob", apply = { function = "yearsElapsed", params = [
+        "$add_date",
+        "%d/%m/%Y",
+        "%d/%m/%Y",
+      ] } },
+    ]
 
   [subject.date_of_birth]
     field = "dob"
@@ -280,8 +285,22 @@
     ]
 
   [subject.dob_month]
-    field = "dob"
-    apply = { function = "splitDate", params = ["month", "%d/%m/%Y"] }
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "month",
+        "%d/%m/%Y",
+      ] } },
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%d/%m/%Y",
+      ] } },
+      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
 
   [subject.dob_day]
     field = "dob"

--- a/isaric/parsers/ccp-ghana.toml
+++ b/isaric/parsers/ccp-ghana.toml
@@ -253,6 +253,7 @@
       { field = "age", description = "Age", source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }, unit = "years" },
       { field = "dob", apply = { function = "yearsElapsed", params = [
         "$add_date",
+        2022,
         "%d/%m/%Y",
         "%d/%m/%Y",
       ] } },
@@ -266,19 +267,35 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "year",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if.any = [
+        { age_unit = 1 },
+        { age_unit = "" },
+      ], apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$recruit_date",
+        ],
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$recruit_date",
+        ],
+        2022,
         "%d/%m/%Y",
         "months",
       ] } },
-      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$recruit_date",
+        ],
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },
@@ -289,14 +306,23 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "month",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        [
+          "$add_date",
+          "$recruit_date",
+        ],
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        [
+          "$add_date",
+          "$recruit_date",
+        ],
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },
@@ -304,7 +330,7 @@
 
   [subject.dob_day]
     field = "dob"
-    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
+    apply = { function = "splitDate", params = ["day", 2022, "%d/%m/%Y"] }
 
   [subject.works_microbiology_lab]
     field = "microb"
@@ -917,11 +943,11 @@
     field = "adm21s2"
     description = "AVPU: responsiveness scale:"
 
-  [observation.value.values]
-    1 = "Alert"
-    2 = "Verbal"
-    3 = "Pain"
-    4 = "Unresponsive"
+    [observation.text.values]
+      1 = "Alert"
+      2 = "Verbal"
+      3 = "Pain"
+      4 = "Unresponsive"
 
 [[observation]]
   name = "base_excess"

--- a/isaric/parsers/ccp-ghana.toml
+++ b/isaric/parsers/ccp-ghana.toml
@@ -26,7 +26,7 @@
 
 [adtl.defs]
   "Y/N/NK" = { values = { 0 = false, 1 = true } }
-  uid = { field = "record_id" }
+  uid = { field = "record_id", sensitive = true }
 
   [adtl.defs.admissionDateHierarchy]
     combinedType = "firstNonNull"
@@ -252,6 +252,40 @@
     description = "Age"
     source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
     unit = "years"
+
+  [subject.date_of_birth]
+    field = "dob"
+
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "year",
+        "%d/%m/%Y",
+      ] } },
+      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+      ] } },
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+        "months",
+      ] } },
+      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    field = "dob"
+    apply = { function = "splitDate", params = ["month", "%d/%m/%Y"] }
+
+  [subject.dob_day]
+    field = "dob"
+    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
 
   [subject.works_microbiology_lab]
     field = "microb"
@@ -864,11 +898,11 @@
     field = "adm21s2"
     description = "AVPU: responsiveness scale:"
 
-    [observation.value.values]
-      1 = "Alert"
-      2 = "Verbal"
-      3 = "Pain"
-      4 = "Unresponsive"
+  [observation.value.values]
+    1 = "Alert"
+    2 = "Verbal"
+    3 = "Pain"
+    4 = "Unresponsive"
 
 [[observation]]
   name = "base_excess"

--- a/isaric/parsers/ccp-guinea.toml
+++ b/isaric/parsers/ccp-guinea.toml
@@ -252,20 +252,26 @@
     values = { 0 = "female", 1 = "male" }
 
   [subject.age]
-    field = "age"
-    description = "Age"
-    source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
-    unit = "years"
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "age", description = "Age", source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }, unit = "years" },
+      { field = "dob", apply = { function = "yearsElapsed", params = [
+        "$signes_date_t",
+        "%d/%m/%Y",
+        "%d/%m/%Y %H:%M",
+      ] } },
+    ]
 
   [subject.date_of_birth]
     field = "dob"
+    source_date = "%d/%m/%Y"
 
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "year",
-        "%d/%m/%Y %H:%M",
+        "%d/%m/%Y",
       ] } },
       { field = "signes_date_t", if = { age_unit = 1 }, apply = { function = "startYear", params = [
         "$age",
@@ -276,15 +282,34 @@
         "%d/%m/%Y %H:%M",
         "months",
       ] } },
+      { field = "signes_date_t", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y %H:%M",
+        "days",
+      ] } },
     ]
 
   [subject.dob_month]
-    field = "dob"
-    apply = { function = "splitDate", params = ["month", "%d/%m/%Y %H:%M"] }
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "month",
+        "%d/%m/%Y",
+      ] } },
+      { field = "signes_date_t", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%d/%m/%Y %H:%M",
+      ] } },
+      { field = "signes_date_t", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%d/%m/%Y %H:%M",
+        "days",
+      ] } },
+    ]
 
   [subject.dob_day]
     field = "dob"
-    apply = { function = "splitDate", params = ["day", "%d/%m/%Y %H:%M"] }
+    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
 
   [subject.ethnicity]
     combinedType = "set"

--- a/isaric/parsers/ccp-guinea.toml
+++ b/isaric/parsers/ccp-guinea.toml
@@ -257,6 +257,7 @@
       { field = "age", description = "Age", source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }, unit = "years" },
       { field = "dob", apply = { function = "yearsElapsed", params = [
         "$signes_date_t",
+        2022,
         "%d/%m/%Y",
         "%d/%m/%Y %H:%M",
       ] } },
@@ -271,19 +272,29 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "year",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "signes_date_t", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if.any = [
+        { age_unit = 1 },
+        { age_unit = "" },
+      ], apply = { function = "startYear", params = [
+        [
+          "$signes_date_t",
+          "$demo_date_t",
+        ],
+        2022,
         "%d/%m/%Y %H:%M",
       ] } },
-      { field = "signes_date_t", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$signes_date_t",
+        2022,
         "%d/%m/%Y %H:%M",
         "months",
       ] } },
-      { field = "signes_date_t", if = { age_unit = 3 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$signes_date_t",
+        2022,
         "%d/%m/%Y %H:%M",
         "days",
       ] } },
@@ -294,14 +305,17 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "month",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "signes_date_t", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$signes_date_t",
+        2022,
         "%d/%m/%Y %H:%M",
       ] } },
-      { field = "signes_date_t", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$signes_date_t",
+        2022,
         "%d/%m/%Y %H:%M",
         "days",
       ] } },
@@ -309,7 +323,7 @@
 
   [subject.dob_day]
     field = "dob"
-    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
+    apply = { function = "splitDate", params = ["day", 2022, "%d/%m/%Y"] }
 
   [subject.ethnicity]
     combinedType = "set"

--- a/isaric/parsers/ccp-guinea.toml
+++ b/isaric/parsers/ccp-guinea.toml
@@ -257,6 +257,35 @@
     source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
     unit = "years"
 
+  [subject.date_of_birth]
+    field = "dob"
+
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "year",
+        "%d/%m/%Y %H:%M",
+      ] } },
+      { field = "signes_date_t", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y %H:%M",
+      ] } },
+      { field = "signes_date_t", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y %H:%M",
+        "months",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    field = "dob"
+    apply = { function = "splitDate", params = ["month", "%d/%m/%Y %H:%M"] }
+
+  [subject.dob_day]
+    field = "dob"
+    apply = { function = "splitDate", params = ["day", "%d/%m/%Y %H:%M"] }
+
   [subject.ethnicity]
     combinedType = "set"
     excludeWhen = "none"

--- a/isaric/parsers/ccp-senegal.toml
+++ b/isaric/parsers/ccp-senegal.toml
@@ -63,6 +63,20 @@
     unit = "years"
     source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years" } }
 
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "hostdat_year", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+        "%Y",
+      ] } },
+      # { field = "hostdat_year", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+      #   "$age_estimateyears",
+      #   "%Y",
+      #   "months",
+      # ] } }, # how to do this - dates are made by combining d + m + y fields but can't do that within the function.
+    ]
+
   [subject.date_death]
     combinedType = "firstNonNull"
     fields = [

--- a/isaric/parsers/ccp-senegal.toml
+++ b/isaric/parsers/ccp-senegal.toml
@@ -66,16 +66,36 @@
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
-      { field = "hostdat_year", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+        "$hostdat_year",
+        2022,
         "%Y",
       ] } },
-      # { field = "hostdat_year", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-      #   "$age_estimateyears",
-      #   "%Y",
-      #   "months",
-      # ] } }, # how to do this - dates are made by combining d + m + y fields but can't do that within the function.
+      { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+        "$hostdat_year",
+        2022,
+        "",
+        "months",
+        [
+          "$hostdat_month",
+          "$hostdat_day",
+        ],
+      ] } },
     ]
+
+  [subject.dob_month]
+    field = "age_estimateyears"
+    if = { age_estimateyearsu = 1 }
+    apply = { function = "startMonth", params = [
+      "$hostdat_year",
+      2022,
+      "",
+      "months",
+      [
+        "$hostdat_month",
+        "$hostdat_day",
+      ],
+    ] }
 
   [subject.date_death]
     combinedType = "firstNonNull"

--- a/isaric/parsers/ccp-uganda-v2.toml
+++ b/isaric/parsers/ccp-uganda-v2.toml
@@ -57,6 +57,24 @@
     source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
     unit = "years"
 
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age",
+      ] } },
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age",
+        "%Y-%m-%d",
+        "months",
+      ] } },
+      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$age",
+        "%Y-%m-%d",
+        "days",
+      ] } },
+    ]
+
   [subject.sex]
     field = "sex"
     description = "Gender"

--- a/isaric/parsers/ccp-uganda-v2.toml
+++ b/isaric/parsers/ccp-uganda-v2.toml
@@ -60,16 +60,32 @@
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
-      { field = "add_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if.any = [
+        { age_unit = 1 },
+        { age_unit = "" },
+      ], apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$onset_date",
+          "$investigate_date",
+        ],
+        2022,
       ] } },
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$onset_date",
+        ],
+        2022,
         "%Y-%m-%d",
         "months",
       ] } },
-      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        [
+          "$add_date",
+          "$onset_date",
+        ],
+        2022,
         "%Y-%m-%d",
         "days",
       ] } },
@@ -78,11 +94,13 @@
   [subject.dob_month]
     combinedType = "firstNonNull"
     fields = [
-      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$add_date",
+        2022,
       ] } },
-      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$add_date",
+        2022,
         "%Y-%m-%d",
         "days",
       ] } },

--- a/isaric/parsers/ccp-uganda-v2.toml
+++ b/isaric/parsers/ccp-uganda-v2.toml
@@ -75,6 +75,19 @@
       ] } },
     ]
 
+  [subject.dob_month]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "add_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$age",
+      ] } },
+      { field = "add_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%Y-%m-%d",
+        "days",
+      ] } },
+    ]
+
   [subject.sex]
     field = "sex"
     description = "Gender"

--- a/isaric/parsers/datcov-southafrica.toml
+++ b/isaric/parsers/datcov-southafrica.toml
@@ -29,7 +29,7 @@
 [adtl.defs.admissionDateHierarchy]
   combinedType = "firstNonNull"
   fields = [
-    { field = "Adm Date.AdmissionDate", source_date = "%m/%d/%Y" },
+    { field = "Adm Date.AdmissionDate", source_date = "%m/%d/%y" },
     { field = "date_of_admis_datcov" },
     { field = "flw_hospital_admit", description = "Roughly what date were you first admitted to hospital?" },
   ]
@@ -58,30 +58,40 @@
     ref = "admissionDateHierarchy"
 
   [subject.age]
-    field = "Age"
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "Age" },
+      { field = "BirthDate", apply = { function = "yearsElapsed", params = [
+        "$Adm Date.AdmissionDate",
+        "%m/%d/%y",
+        "%m/%d/%y",
+      ] } },
+    ]
 
-  [subject.date_of_birth]
+  [subject.date_of_birth] # NOTE: many dates have 2-digit years - this often autoconverts to 20xx not 19xx for older people.
     field = "BirthDate"
+    apply = { function = "correctOldDate", params = ["%m/%d/%y"] }
 
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
       { field = "BirthDate", apply = { function = "splitDate", params = [
         "year",
+        "%m/%d/%y",
       ] } },
       { field = "Adm Date.AdmissionDate", apply = { function = "startYear", params = [
         "$Age",
-        "%m/%d/%Y",
+        "%m/%d/%y",
       ] } },
     ]
 
   [subject.dob_month]
     field = "BirthDate"
-    apply = { function = "splitDate", params = ["month"] }
+    apply = { function = "splitDate", params = ["month", "%m/%d/%y"] }
 
   [subject.dob_day]
     field = "BirthDate"
-    apply = { function = "splitDate", params = ["day"] }
+    apply = { function = "splitDate", params = ["day", "%m/%d/%y"] }
 
   [subject.sex_at_birth]
     field = "BirthSex"

--- a/isaric/parsers/datcov-southafrica.toml
+++ b/isaric/parsers/datcov-southafrica.toml
@@ -63,6 +63,7 @@
       { field = "Age" },
       { field = "BirthDate", apply = { function = "yearsElapsed", params = [
         "$Adm Date.AdmissionDate",
+        2022,
         "%m/%d/%y",
         "%m/%d/%y",
       ] } },
@@ -70,28 +71,30 @@
 
   [subject.date_of_birth] # NOTE: many dates have 2-digit years - this often autoconverts to 20xx not 19xx for older people.
     field = "BirthDate"
-    apply = { function = "correctOldDate", params = ["%m/%d/%y"] }
+    apply = { function = "correctOldDate", params = [2022, "%m/%d/%y"] }
 
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
       { field = "BirthDate", apply = { function = "splitDate", params = [
         "year",
+        2022,
         "%m/%d/%y",
       ] } },
-      { field = "Adm Date.AdmissionDate", apply = { function = "startYear", params = [
-        "$Age",
+      { field = "Age", apply = { function = "startYear", params = [
+        "$Adm Date.AdmissionDate",
+        2022,
         "%m/%d/%y",
       ] } },
     ]
 
   [subject.dob_month]
     field = "BirthDate"
-    apply = { function = "splitDate", params = ["month", "%m/%d/%y"] }
+    apply = { function = "splitDate", params = ["month", 2022, "%m/%d/%y"] }
 
   [subject.dob_day]
     field = "BirthDate"
-    apply = { function = "splitDate", params = ["day", "%m/%d/%y"] }
+    apply = { function = "splitDate", params = ["day", 2022, "%m/%d/%y"] }
 
   [subject.sex_at_birth]
     field = "BirthSex"

--- a/isaric/parsers/datcov-southafrica.toml
+++ b/isaric/parsers/datcov-southafrica.toml
@@ -29,7 +29,7 @@
 [adtl.defs.admissionDateHierarchy]
   combinedType = "firstNonNull"
   fields = [
-    { field = "Adm Date.AdmissionDate", source_date = "%m/%d/%y" },
+    { field = "Adm Date.AdmissionDate", source_date = "%m/%d/%Y" },
     { field = "date_of_admis_datcov" },
     { field = "flw_hospital_admit", description = "Roughly what date were you first admitted to hospital?" },
   ]
@@ -59,6 +59,29 @@
 
   [subject.age]
     field = "Age"
+
+  [subject.date_of_birth]
+    field = "BirthDate"
+
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "BirthDate", apply = { function = "splitDate", params = [
+        "year",
+      ] } },
+      { field = "Adm Date.AdmissionDate", apply = { function = "startYear", params = [
+        "$Age",
+        "%m/%d/%Y",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    field = "BirthDate"
+    apply = { function = "splitDate", params = ["month"] }
+
+  [subject.dob_day]
+    field = "BirthDate"
+    apply = { function = "splitDate", params = ["day"] }
 
   [subject.sex_at_birth]
     field = "BirthSex"

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -129,8 +129,18 @@
   ]
 
 [subject.dob_month]
-  field = "dob"
-  apply = { function = "splitDate", params = ["month"] }
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "dob", apply = { function = "splitDate", params = [
+      "month",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d",
+      "months",
+    ] } },
+  ]
+
 
 [subject.dob_day]
   field = "dob"

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -109,7 +109,7 @@
 [subject.date_of_birth]
   field = "agedat"
 
-[subject.dob_year] # for some reason if neither an admission date nor an enrolement date is present, this returns none even if a DoB is present?
+[subject.dob_year]
   combinedType = "firstNonNull"
   fields = [
     { field = "agedat", apply = { function = "splitDate", params = [
@@ -1000,7 +1000,7 @@
   name = "pao2_mmHg"
   phase = "study"
   date = { field = "daily_dsstdat", description = "Date of assessment" }
-  value = { field = "daily_pao2_lborres", source_unit = { field = "daily_pao2_lborresu", values = { 1 = "kPa", 2 = "mmHg" }, unit = "mmHg" } }
+  value = { field = "daily_pao2_lborres", source_unit = { field = "daily_pao2_lborresu", values = { 1 = "kPa", 2 = "mmHg" } }, unit = "mmHg" }
   [observation.context]
     combinedType = "set"
     excludeWhen = "none"

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -106,6 +106,36 @@
         field = "age_estimateyearsu"
         values = { 1 = "months", 2 = "years" }
 
+[subject.date_of_birth]
+  field = "dob"
+
+[subject.dob_year]
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "dob", apply = { function = "splitDate", params = [
+      "year",
+    ] } },
+    { field = "hostdat", apply = { function = "startYear", params = [
+      "$calc_age",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+      "$age_estimateyears",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d",
+      "months",
+    ] } },
+  ]
+
+[subject.dob_month]
+  field = "dob"
+  apply = { function = "splitDate", params = ["month"] }
+
+[subject.dob_day]
+  field = "dob"
+  apply = { function = "splitDate", params = ["day"] }
+
 [subject.pregnancy]
   field = "pregyn_rptestcd"
   ref = "Y/N/NK"

--- a/isaric/parsers/isaric-ccpuk.toml
+++ b/isaric/parsers/isaric-ccpuk.toml
@@ -107,22 +107,44 @@
         values = { 1 = "months", 2 = "years" }
 
 [subject.date_of_birth]
-  field = "dob"
+  field = "agedat"
 
-[subject.dob_year]
+[subject.dob_year] # for some reason if neither an admission date nor an enrolement date is present, this returns none even if a DoB is present?
   combinedType = "firstNonNull"
   fields = [
-    { field = "dob", apply = { function = "splitDate", params = [
+    { field = "agedat", apply = { function = "splitDate", params = [
       "year",
+      2022,
     ] } },
-    { field = "hostdat", apply = { function = "startYear", params = [
-      "$calc_age",
+    { field = "calc_age", apply = { function = "startYear", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+        "$daily_dsstdat",
+      ],
+      2022,
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if.any = [
+      { age_estimateyearsu = 2 },
+      { age_estimateyearsu = "" },
+    ], apply = { function = "startYear", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+        "$daily_dsstdat",
+      ],
+      2022,
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+        "$daily_dsstdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "months",
     ] } },
@@ -131,11 +153,18 @@
 [subject.dob_month]
   combinedType = "firstNonNull"
   fields = [
-    { field = "dob", apply = { function = "splitDate", params = [
+    { field = "agedat", apply = { function = "splitDate", params = [
       "month",
+      2022,
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+        "$daily_dsstdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "months",
     ] } },
@@ -143,8 +172,8 @@
 
 
 [subject.dob_day]
-  field = "dob"
-  apply = { function = "splitDate", params = ["day"] }
+  field = "agedat"
+  apply = { function = "splitDate", params = ["day", 2022] }
 
 [subject.pregnancy]
   field = "pregyn_rptestcd"

--- a/isaric/parsers/isaric-ecmo.toml
+++ b/isaric/parsers/isaric-ecmo.toml
@@ -296,16 +296,37 @@
 [subject.dob_year]
   combinedType = "firstNonNull"
   fields = [
-    { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if.any = [
+      { age_estimateyearsu = 2 },
+      { age_estimateyearsu = "" },
+    ], apply = { function = "startYear", params = [
+      [
+        "$icu_hostdat",
+        "$hostdat",
+        "$dsstdat",
+        "$cestdat",
+      ],
+      2022,
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+      [
+        "$icu_hostdat",
+        "$hostdat",
+        "$dsstdat",
+        "$cestdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "months",
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
+      [
+        "$icu_hostdat",
+        "$hostdat",
+        "$dsstdat",
+        "$cestdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "days",
     ] } },
@@ -314,11 +335,23 @@
 [subject.dob_month]
   combinedType = "firstNonNull"
   fields = [
-    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+      [
+        "$icu_hostdat",
+        "$hostdat",
+        "$dsstdat",
+        "$cestdat",
+      ],
+      2022,
     ] } },
-    { field = "hostdat", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
-      "$age_estimateyears",
+    { field = "age_estimateyears", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
+      [
+        "$icu_hostdat",
+        "$hostdat",
+        "$dsstdat",
+        "$cestdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "days",
     ] } },

--- a/isaric/parsers/isaric-ecmo.toml
+++ b/isaric/parsers/isaric-ecmo.toml
@@ -311,6 +311,19 @@
     ] } },
   ]
 
+[subject.dob_month]
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+      "$age_estimateyears",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d",
+      "days",
+    ] } },
+  ]
+
 [subject.pregnancy]
   field = "pregyn_rptestcd"
   ref = "Y/N/NK"

--- a/isaric/parsers/isaric-ecmo.toml
+++ b/isaric/parsers/isaric-ecmo.toml
@@ -285,20 +285,31 @@
     description = "Employed as a healthcare worker?"
 
   [subject.age]
-    combinedType = "firstNonNull"
-    [[subject.age.fields]]
-      field = "age_estimate10"
-      unit = "years"
-      description = "Calculated age in years"
+    field = "age_estimateyears"
+    unit = "years"
+    description = "Age/Estimated age"
 
-    [[subject.age.fields]]
-      field = "age_estimateyears"
-      unit = "years"
-      description = "Age/Estimated age"
+    [subject.age.source_unit]
+      field = "age_estimateyearsu"
+      values = { 1 = "months", 2 = "years", 3 = "days" }
 
-      [subject.age.fields.source_unit]
-        field = "age_estimateyearsu"
-        values = { 1 = "months", 2 = "years", 3 = "days" }
+[subject.dob_year]
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+      "$age_estimateyears",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d",
+      "months",
+    ] } },
+    { field = "hostdat", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d",
+      "days",
+    ] } },
+  ]
 
 [subject.pregnancy]
   field = "pregyn_rptestcd"

--- a/isaric/parsers/isaric-rapid.toml
+++ b/isaric/parsers/isaric-rapid.toml
@@ -299,7 +299,7 @@
 
     [[subject.age.fields]]
       field = "brthdtc"
-      apply = { function = "yearsElapsed", params = ["$dsstdat"] }
+      apply = { function = "yearsElapsed", params = ["$dsstdat", 2022] }
 
     [[subject.age.fields]]
       field = "age"
@@ -314,12 +314,23 @@
   fields = [
     { field = "brthdtc", apply = { function = "splitDate", params = [
       "year",
+      2022,
     ] } },
-    { field = "hostdat", if = { ageu = 2 }, apply = { function = "startYear", params = [
-      "$age",
+    { field = "age", if = { ageu = 2 }, apply = { function = "startYear", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+      ],
+      2022,
     ] } },
-    { field = "hostdat", if = { ageu = 1 }, apply = { function = "startYear", params = [
-      "$age",
+    { field = "age", if = { ageu = 1 }, apply = { function = "startYear", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+      ],
+      2022,
       "%Y-%m-%d",
       "months",
     ] } },
@@ -330,15 +341,21 @@
   fields = [
     { field = "brthdtc", apply = { function = "splitDate", params = [
       "month",
+      2022,
     ] } },
-    { field = "hostdat", if = { ageu = 1 }, apply = { function = "startMonth", params = [
-      "$age",
+    { field = "age", if = { ageu = 1 }, apply = { function = "startMonth", params = [
+      [
+        "$hostdat",
+        "$cestdat",
+        "$dsstdat",
+      ],
+      2022,
     ] } },
   ]
 
 [subject.dob_day]
   field = "brthdtc"
-  apply = { function = "splitDate", params = ["day"] }
+  apply = { function = "splitDate", params = ["day", 2022] }
 
 [subject.pregnancy]
   field = "pregyn_rptestcd"
@@ -1500,7 +1517,7 @@
   phase = "admission"
   date = { ref = "admissionDateHierarchy" }
   context = ["highest"]
-  value = { field = "temp_vsorres" }        # there is no source unit field
+  value = { field = "temp_vsorres" }        # there is no source unit field, but a mix of celsius and farenheit in the data.
 
 [[observation]]
   name = "temperature_celsius"

--- a/isaric/parsers/isaric-rapid.toml
+++ b/isaric/parsers/isaric-rapid.toml
@@ -306,6 +306,33 @@
       unit = "years"
       source_unit = { field = "ageu", values = { 1 = "months", 2 = "years" } }
 
+[subject.date_of_birth]
+  field = "brthdtc"
+
+[subject.dob_year]
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "brthdtc", apply = { function = "splitDate", params = [
+      "year",
+    ] } },
+    { field = "hostdat", if = { ageu = 2 }, apply = { function = "startDate", params = [
+      "$age",
+    ] } },
+    { field = "hostdat", if = { ageu = 1 }, apply = { function = "startYear", params = [
+      "$age",
+      "%Y-%m-%d",
+      "months",
+    ] } },
+  ]
+
+[subject.dob_month]
+  field = "brthdtc"
+  apply = { function = "splitDate", params = ["month"] }
+
+[subject.dob_day]
+  field = "brthdtc"
+  apply = { function = "splitDate", params = ["day"] }
+
 [subject.pregnancy]
   field = "pregyn_rptestcd"
   description = "Pregnant ?"
@@ -1441,7 +1468,7 @@
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  value = { field = "flw_walking_today" } #, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
+  value = { field = "flw_walking_today" }  #, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
 
 [[observation]]
   name = "inability_to_walk_scale"
@@ -1453,7 +1480,7 @@
   name = "inability_to_walk_scale"
   phase = "followup"
   date = { ref = "followupDateHierarchy" }
-  value = { field = "flw2_walking_today" }#, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
+  value = { field = "flw2_walking_today" } #, values = { 1 = "No difficulty", 2 = "Some difficulty", 3 = "Lots of difficulty", 4 = "Unable to walk" } }
 
 [[observation]]
   name = "clinical_frailty_score"

--- a/isaric/parsers/isaric-rapid.toml
+++ b/isaric/parsers/isaric-rapid.toml
@@ -315,7 +315,7 @@
     { field = "brthdtc", apply = { function = "splitDate", params = [
       "year",
     ] } },
-    { field = "hostdat", if = { ageu = 2 }, apply = { function = "startDate", params = [
+    { field = "hostdat", if = { ageu = 2 }, apply = { function = "startYear", params = [
       "$age",
     ] } },
     { field = "hostdat", if = { ageu = 1 }, apply = { function = "startYear", params = [
@@ -326,8 +326,15 @@
   ]
 
 [subject.dob_month]
-  field = "brthdtc"
-  apply = { function = "splitDate", params = ["month"] }
+  combinedType = "firstNonNull"
+  fields = [
+    { field = "brthdtc", apply = { function = "splitDate", params = [
+      "month",
+    ] } },
+    { field = "hostdat", if = { ageu = 1 }, apply = { function = "startMonth", params = [
+      "$age",
+    ] } },
+  ]
 
 [subject.dob_day]
   field = "brthdtc"

--- a/isaric/parsers/ncov-france.toml
+++ b/isaric/parsers/ncov-france.toml
@@ -47,6 +47,10 @@
       { field = "igs_age", description = "SAPS II: Age (years)", values = { 0 = "<40", 7 = "40-59", 12 = "60-69", 15 = "70-74", 16 = "75-79", 18 = ">=80" } },
     ]
 
+  [subject.dob_year]
+    field = "an_nais"
+    description = "year of birth"
+
   [subject.sex]
     field = "sexe"
     description = "Gender"

--- a/isaric/parsers/ncov-france.toml
+++ b/isaric/parsers/ncov-france.toml
@@ -41,6 +41,7 @@
     fields = [
       { field = "an_nais", apply = { function = "yearsElapsed", params = [
         "$adm_hosp_dh",
+        2022,
         "%Y",
         "%Y-%m-%d %H:%M",
       ] } },

--- a/isaric/parsers/ncov-malaysia.toml
+++ b/isaric/parsers/ncov-malaysia.toml
@@ -46,6 +46,40 @@
     unit = "years"
     source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years", 3 = "days" } }
 
+  [subject.date_of_birth]
+    field = "dob"
+
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "year",
+        "%d/%m/%Y",
+      ] } },
+      { field = "case_class_adm_date", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+        "%d/%m/%Y",
+      ] } },
+      { field = "case_class_adm_date", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+        "%d/%m/%Y",
+        "months",
+      ] } },
+      { field = "case_class_adm_date", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    field = "dob"
+    apply = { function = "splitDate", params = ["month", "%d/%m/%Y"] }
+
+  [subject.dob_day]
+    field = "dob"
+    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
+
   [subject.sex_at_birth]
     field = "sex"
     description = "Sex at birth:"

--- a/isaric/parsers/ncov-malaysia.toml
+++ b/isaric/parsers/ncov-malaysia.toml
@@ -46,6 +46,7 @@
       { field = "age_estimateyears", description = "Age/Estimated age", unit = "years", source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years", 3 = "days" } } },
       { field = "dob", apply = { function = "yearsElapsed", params = [
         "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
         "%d/%m/%Y",
       ] } },
@@ -59,19 +60,23 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "year",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "case_class_adm_date", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+        "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "case_class_adm_date", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+        "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
         "months",
       ] } },
-      { field = "case_class_adm_date", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 3 }, apply = { function = "startYear", params = [
+        "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },
@@ -82,14 +87,17 @@
     fields = [
       { field = "dob", apply = { function = "splitDate", params = [
         "month",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "case_class_adm_date", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+        "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "case_class_adm_date", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
+        "$case_class_adm_date",
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },
@@ -98,7 +106,7 @@
 
   [subject.dob_day]
     field = "dob"
-    apply = { function = "splitDate", params = ["day", "%d/%m/%Y"] }
+    apply = { function = "splitDate", params = ["day", 2022, "%d/%m/%Y"] }
 
   [subject.sex_at_birth]
     field = "sex"

--- a/isaric/parsers/ncov-malaysia.toml
+++ b/isaric/parsers/ncov-malaysia.toml
@@ -41,10 +41,15 @@
     fields = [{ ref = "admissionDate" }]
 
   [subject.age]
-    field = "age_estimateyears"
-    description = "Age/Estimated age"
-    unit = "years"
-    source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years", 3 = "days" } }
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "age_estimateyears", description = "Age/Estimated age", unit = "years", source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years", 3 = "days" } } },
+      { field = "dob", apply = { function = "yearsElapsed", params = [
+        "$case_class_adm_date",
+        "%d/%m/%Y",
+        "%d/%m/%Y",
+      ] } },
+    ]
 
   [subject.date_of_birth]
     field = "dob"
@@ -73,8 +78,23 @@
     ]
 
   [subject.dob_month]
-    field = "dob"
-    apply = { function = "splitDate", params = ["month", "%d/%m/%Y"] }
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "dob", apply = { function = "splitDate", params = [
+        "month",
+        "%d/%m/%Y",
+      ] } },
+      { field = "case_class_adm_date", if = { age_estimateyearsu = 1 }, apply = { function = "startMonth", params = [
+        "$age_estimateyears",
+        "%d/%m/%Y",
+      ] } },
+      { field = "case_class_adm_date", if = { age_estimateyearsu = 3 }, apply = { function = "startMonth", params = [
+        "$age_estimateyears",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
+
 
   [subject.dob_day]
     field = "dob"

--- a/isaric/parsers/sprintsari-australia.toml
+++ b/isaric/parsers/sprintsari-australia.toml
@@ -48,6 +48,19 @@
     unit = "years"
     source_unit = { field = "age_estimateyearsu", values = { 1 = "months", 2 = "years" } }
 
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "hostdat", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+      ] } },
+      { field = "hostdat", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age_estimateyears",
+        "%Y-%m-%d",
+        "months",
+      ] } },
+    ]
+
   [subject.sex_at_birth]
     field = "sex"
     description = "Sex at birth:"

--- a/isaric/parsers/sprintsari-australia.toml
+++ b/isaric/parsers/sprintsari-australia.toml
@@ -51,22 +51,25 @@
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
-      { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
+        "$hostdat",
+        2022,
         "%Y-%m-%d %H:%M",
       ] } },
-      { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
-        "$age_estimateyears",
+      { field = "age_estimateyears", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
+        "$hostdat",
+        2022,
         "%Y-%m-%d %H:%M",
         "months",
       ] } },
     ]
 
   [subject.dob_month]
-    field = "hostdat"
+    field = "age_estimateyears"
     if = { age_estimateyearsu = 1 }
     apply = { function = "startMonth", params = [
-      "$age_estimateyears",
+      "$hostdat",
+      2022,
       "%Y-%m-%d %H:%M",
     ] }
 

--- a/isaric/parsers/sprintsari-australia.toml
+++ b/isaric/parsers/sprintsari-australia.toml
@@ -51,15 +51,24 @@
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
-      { field = "hostdat", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+      { field = "hostdat", if = { age_estimateyearsu = 2 }, apply = { function = "startYear", params = [
         "$age_estimateyears",
+        "%Y-%m-%d %H:%M",
       ] } },
-      { field = "hostdat", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+      { field = "hostdat", if = { age_estimateyearsu = 1 }, apply = { function = "startYear", params = [
         "$age_estimateyears",
-        "%Y-%m-%d",
+        "%Y-%m-%d %H:%M",
         "months",
       ] } },
     ]
+
+  [subject.dob_month]
+    field = "hostdat"
+    if = { age_estimateyearsu = 1 }
+    apply = { function = "startMonth", params = [
+      "$age_estimateyears",
+      "%Y-%m-%d %H:%M",
+    ] }
 
   [subject.sex_at_birth]
     field = "sex"
@@ -441,7 +450,7 @@
   name = "bleeding"
   date = { ref = "admissionDateHierarchy" }
   phase = "admission"
-  is_present = { field = "bleed_ceterm_v2", ref = "Y/N/NK", description = "Bleeding (others)" }
+  is_present = { field = "bleed_ceterm_v2", ref = "Y/N", description = "Bleeding (others)" }
 
 [[observation]]
   name = "chest_pain"

--- a/isaric/parsers/uganda-vri-v1.toml
+++ b/isaric/parsers/uganda-vri-v1.toml
@@ -45,6 +45,24 @@
     source_unit = { field = "age_unit", values = { 1 = "years", 2 = "months", 3 = "days" } }
     unit = "years"
 
+  [subject.dob_year]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "hospitalization_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$age",
+      ] } },
+      { field = "hospitalization_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+        "months",
+      ] } },
+      { field = "hospitalization_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
+
   [subject.sex]
     field = "sex"
     values = { 1 = "male", 0 = "female" }

--- a/isaric/parsers/uganda-vri-v1.toml
+++ b/isaric/parsers/uganda-vri-v1.toml
@@ -50,6 +50,7 @@
     fields = [
       { field = "hospitalization_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
         "$age",
+        "%d/%m/%Y",
       ] } },
       { field = "hospitalization_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
         "$age",
@@ -57,6 +58,20 @@
         "months",
       ] } },
       { field = "hospitalization_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$age",
+        "%d/%m/%Y",
+        "days",
+      ] } },
+    ]
+
+  [subject.dob_month]
+    combinedType = "firstNonNull"
+    fields = [
+      { field = "hospitalization_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$age",
+        "%d/%m/%Y",
+      ] } },
+      { field = "hospitalization_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
         "$age",
         "%d/%m/%Y",
         "days",

--- a/isaric/parsers/uganda-vri-v1.toml
+++ b/isaric/parsers/uganda-vri-v1.toml
@@ -48,17 +48,20 @@
   [subject.dob_year]
     combinedType = "firstNonNull"
     fields = [
-      { field = "hospitalization_date", if = { age_unit = 1 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 1 }, apply = { function = "startYear", params = [
+        "$hospitalization_date",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "hospitalization_date", if = { age_unit = 2 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startYear", params = [
+        "$hospitalization_date",
+        2022,
         "%d/%m/%Y",
         "months",
       ] } },
-      { field = "hospitalization_date", if = { age_unit = 3 }, apply = { function = "startYear", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startYear", params = [
+        "$hospitalization_date",
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },
@@ -67,12 +70,14 @@
   [subject.dob_month]
     combinedType = "firstNonNull"
     fields = [
-      { field = "hospitalization_date", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 2 }, apply = { function = "startMonth", params = [
+        "$hospitalization_date",
+        2022,
         "%d/%m/%Y",
       ] } },
-      { field = "hospitalization_date", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
-        "$age",
+      { field = "age", if = { age_unit = 3 }, apply = { function = "startMonth", params = [
+        "$hospitalization_date",
+        2022,
         "%d/%m/%Y",
         "days",
       ] } },

--- a/isaric/parsers/western-australia.toml
+++ b/isaric/parsers/western-australia.toml
@@ -79,8 +79,17 @@
     #   field = "brthdtc"
 
   [subject.dob_year]
-    field = "dsstdat"
-    apply = { function = "startYear", params = ["$age_calc", "%d/%m/%Y"] }
+    field = "age_calc"
+    apply = { function = "startYear", params = [
+      [
+        "$admission_date",
+        "$hostdat",
+        "$dsstdat",
+      ],
+      2022,
+      "%d/%m/%Y",
+    ] }
+
 
   [subject.works_healthcare]
     field = "healthwork_erterm"

--- a/isaric/parsers/western-australia.toml
+++ b/isaric/parsers/western-australia.toml
@@ -70,15 +70,17 @@
     ]
 
   [subject.age]
-    combinedType = 'firstNonNull'
-    fields = [
-      { field = "age_calc", description = "Calculated age (form)" },
-      # { field = "age", unit = "years", source_unit = { field = "ageu", values = { 1 = "months", 2 = "years" } } },
-      # { field = "brthdtc", description = "Calculate from birth date", apply = { function = "yearsElapsed", params = [
-      # "admission_date",
-      # ] } },
-    ]
+    field = "age_calc"
+    description = "Calculated age (form)"
+    unit = "years"
+    # source_unit = { field = "ageu", values = { 1 = "months", 2 = "years" } }
 
+    # [subject.date_of_birth]
+    #   field = "brthdtc"
+
+  [subject.dob_year]
+    field = "dsstdat"
+    apply = { function = "startYear", params = ["$age_calc", "%d/%m/%Y"] }
 
   [subject.works_healthcare]
     field = "healthwork_erterm"
@@ -909,13 +911,13 @@
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
-  date = { field = "dsstdtc" }                                           # Can't find a date for the followup forms specifically
+  date = { field = "dsstdtc" }                                            # Can't find a date for the followup forms specifically
   value = { field = "basline_mobility_discharge", ref = "inabilityWalk" }
 
 [[observation]]
   name = "inability_to_walk_scale"
   phase = "followup"
-  date = { field = "dsstdtc" }                                                    # Can't find a date for the followup forms specifically
+  date = { field = "dsstdtc" }                                                     # Can't find a date for the followup forms specifically
   value = { field = "basline_mobility_discharge_followup", ref = "inabilityWalk" }
 
 [[observation]]

--- a/output/ISARIC CCPUK/adtl-output.md
+++ b/output/ISARIC CCPUK/adtl-output.md
@@ -1,16 +1,16 @@
 > adtl isaric/parsers/isaric-ccpuk.toml ../isaric-data/isaric-ccpuk/CCPUKSARILondon_DATA_2022-06-06_1135.csv --include-def isaric/parsers/relsub.json
 
-|table       	|valid	|total	|percentage_valid|
+|table          |valid  |total  |percentage_valid|
 |---------------|-------|-------|----------------|
-
-|subject        |31614  |36754  |86.015128% |
+|subject        |31619  |36754  |86.028732% |
 |visit          |30810  |36754  |83.827611% |
-|observation    |1243439        |1245776        |99.812406% |
+|observation    |1251023        |1259896        |99.295736% |
 
 ## subject
 
-* 4101: data cannot be validated by any definition
-* 1031: data must contain ['subject_id', 'age', 'sex_at_birth', 'ethnicity', 'pathogen'] properties
+* 4153: data cannot be validated by any definition
+* 944: data must contain ['subject_id', 'ethnicity', 'pathogen'] properties
+* 30: data must be valid exactly by one definition (0 matches found)
 * 5: data.age must be smaller than or equal to 120
 * 2: data.earliest_admission_date must be date
 * 1: data.age must be bigger than or equal to 0
@@ -24,6 +24,6 @@
 
 ## observation
 
-* 2257: data must contain ['phase', 'date', 'name'] properties
-* 74: data.date cannot be validated by any definition
-* 6: data.value must be number
+* 6538: data must be valid exactly by one definition (0 matches found)
+* 2260: data must contain ['phase', 'date', 'name'] properties
+* 75: data.date cannot be validated by any definition

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -79,7 +79,8 @@
                   "items": {
                     "type": [
                       "string",
-                      "number"
+                      "number",
+                      "array"
                     ]
                   },
                   "description": "Additional parameters to pass to the function"

--- a/schemas/dev/parser.schema.json
+++ b/schemas/dev/parser.schema.json
@@ -300,6 +300,22 @@
           "description": "Age in years",
           "$ref": "#/definitions/mapping"
         },
+        "date_of_birth": {
+          "description": "Date of birth",
+          "$ref": "#/definitions/mapping"
+        },
+        "dob_year": {
+          "description": "Year of birth",
+          "$ref": "#/definitions/mapping"
+        },
+        "dob_month": {
+          "description": "month of birth",
+          "$ref": "#/definitions/mapping"
+        },
+        "dob_day": {
+          "description": "Day of birth",
+          "$ref": "#/definitions/mapping"
+        },
         "sex_at_birth": {
           "description": "Sex at birth",
           "$ref": "#/definitions/mapping"

--- a/schemas/dev/subject.schema.json
+++ b/schemas/dev/subject.schema.json
@@ -5,19 +5,44 @@
   "description": "A study subject in the ISARIC schema, contains demographics and comorbidities information",
   "required": [
     "subject_id",
-    "age",
     "ethnicity",
     "pathogen"
   ],
   "anyOf": [
     {
       "required": [
-        "earliest_admission_date"
+        "earliest_admission_date",
+        "age"
       ]
     },
     {
       "required": [
-        "enrolment_date"
+        "earliest_admission_date",
+        "date_of_birth"
+      ]
+    },
+    {
+      "required": [
+        "earliest_admission_date",
+        "dob_year"
+      ]
+    },
+    {
+      "required": [
+        "enrolment_date",
+        "age"
+      ]
+    },
+    {
+      "required": [
+        "enrolment_date",
+        "date_of_birth"
+      ]
+    },
+    {
+      "required": [
+        "enrolment_date",
+        "dob_year"
       ]
     }
   ],
@@ -69,6 +94,27 @@
       "minimum": 0,
       "maximum": 120,
       "pattern": "[<]\\d|[>]\\d|\\d+[-]\\d+"
+    },
+    "date_of_birth": {
+      "type": "string",
+      "format": "date",
+      "description": "Date of birth",
+      "category": "demographics"
+    },
+    "dob_year": {
+      "type": "number",
+      "description": "Year of birth",
+      "category": "demographics"
+    },
+    "dob_month": {
+      "type": "number",
+      "description": "Month of birth",
+      "category": "demographics"
+    },
+    "dob_day": {
+      "type": "number",
+      "description": "Day of birth",
+      "category": "demographics"
     },
     "sex_at_birth": {
       "enum": [

--- a/schemas/dev/subject.schema.json
+++ b/schemas/dev/subject.schema.json
@@ -102,19 +102,24 @@
       "category": "demographics"
     },
     "dob_year": {
-      "type": "number",
+      "type": "integer",
       "description": "Year of birth",
-      "category": "demographics"
+      "category": "demographics",
+      "minimum": 1900
     },
     "dob_month": {
-      "type": "number",
+      "type": "integer",
       "description": "Month of birth",
-      "category": "demographics"
+      "category": "demographics",
+      "minimum": 1,
+      "maximum": 12
     },
     "dob_day": {
-      "type": "number",
+      "type": "integer",
       "description": "Day of birth",
-      "category": "demographics"
+      "category": "demographics",
+      "minimum": 1,
+      "maximum": 31
     },
     "sex_at_birth": {
       "enum": [


### PR DESCRIPTION
Adds fields for date_of_birth, dob_year, dob_mont, dob_day.

If a date of birth is provided in the data, it uses this to populate all 4 fields.

If age is provided but not a date of birth, dob_year is calculated based on the admission date, plus dob_month if age is provided in months/days.

Concerns: 
* This doesn't really fix the initial issue of providing more user-friendly values for children/infants where the age is <1.
* Date hierarchies don't work with apply functions, so there are instances where an age/year can't be calculated because the chosen date (either admission date or enrolment date) isn't filled